### PR TITLE
Add mask key for visualization

### DIFF
--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -368,7 +368,8 @@ def _handle_viz_tools(
         image_to_data[image]["scores"].extend(call_result.get("scores", []))
         image_to_data[image]["masks"].extend(call_result.get("masks", []))
         # only single heatmap is returned
-        image_to_data[image]["heat_map"].append(call_result.get("heat_map", []))
+        if "heat_map" in call_result:
+            image_to_data[image]["heat_map"].append(call_result["heat_map"])
         if "mask_shape" in call_result:
             image_to_data[image]["mask_shape"] = call_result["mask_shape"]
 

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -346,7 +346,9 @@ def _handle_viz_tools(
         # 2. return a dictionary but not have the necessary keys
 
         if not isinstance(call_result, dict) or (
-            "bboxes" not in call_result and "heat_map" not in call_result
+            "bboxes" not in call_result
+            and "mask" not in call_result
+            and "heat_map" not in call_result
         ):
             return image_to_data
 


### PR DESCRIPTION
When the `_handle_viz_tools` looks for call results to extract info from it can be a dictionary with "bboxes", "masks" or "heat_map". I forgot to add back in "masks" in the last PR. It actually doesn't matter right now because all tools that return masks also return bboxes.