### PR TITLE
Add Long Term Memory and Feedback

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -51,7 +51,7 @@ def test_call_with_mock(openai_llm_mock):  # noqa: F811
     response = llm([{"role": "user", "content": "test prompt"}])
     assert response == "mocked response"
     openai_llm_mock.chat.completions.create.assert_called_with(
-        model="gpt-4-turbo",
+        model="gpt-4o",
         messages=[{"role": "user", "content": "test prompt"}],
     )
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -18,7 +18,7 @@ def test_generate_with_mock(openai_llm_mock):  # noqa: F811
     response = llm.generate("test prompt")
     assert response == "mocked response"
     openai_llm_mock.chat.completions.create.assert_called_once_with(
-        model="gpt-4-turbo",
+        model="gpt-4o",
         messages=[{"role": "user", "content": "test prompt"}],
     )
 
@@ -31,7 +31,7 @@ def test_chat_with_mock(openai_llm_mock):  # noqa: F811
     response = llm.chat([{"role": "user", "content": "test prompt"}])
     assert response == "mocked response"
     openai_llm_mock.chat.completions.create.assert_called_once_with(
-        model="gpt-4-turbo",
+        model="gpt-4o",
         messages=[{"role": "user", "content": "test prompt"}],
     )
 
@@ -44,7 +44,7 @@ def test_call_with_mock(openai_llm_mock):  # noqa: F811
     response = llm("test prompt")
     assert response == "mocked response"
     openai_llm_mock.chat.completions.create.assert_called_once_with(
-        model="gpt-4-turbo",
+        model="gpt-4o",
         messages=[{"role": "user", "content": "test prompt"}],
     )
 

--- a/vision_agent/agent/vision_agent_v2.py
+++ b/vision_agent/agent/vision_agent_v2.py
@@ -46,6 +46,8 @@ def extract_code(code: str) -> str:
     if "```python" in code:
         code = code[code.find("```python") + len("```python") :]
         code = code[: code.find("```")]
+    if code.startswith("python\n"):
+        code = code[len("python\n") :]
     return code
 
 

--- a/vision_agent/agent/vision_agent_v2.py
+++ b/vision_agent/agent/vision_agent_v2.py
@@ -93,12 +93,7 @@ def write_code(
 
 
 def write_test(
-    user_req: str,
-    subtask: str,
-    tool_info: str,
-    _: str,
-    code: str,
-    model: LLM
+    user_req: str, subtask: str, tool_info: str, _: str, code: str, model: LLM
 ) -> str:
     prompt = TEST.format(
         context=USER_REQ_SUBTASK_CONTEXT.format(

--- a/vision_agent/agent/vision_agent_v2.py
+++ b/vision_agent/agent/vision_agent_v2.py
@@ -91,7 +91,12 @@ def write_code(
 
 
 def write_test(
-    user_req: str, subtask: str, tool_info: str, code: str, model: LLM
+    user_req: str,
+    subtask: str,
+    tool_info: str,
+    _: str,
+    code: str,
+    model: LLM
 ) -> str:
     prompt = TEST.format(
         context=USER_REQ_SUBTASK_CONTEXT.format(
@@ -233,7 +238,7 @@ def run_plan(
             tool_info,
             exec,
             retrieved_ltm,
-            verbose,
+            verbose=verbose,
         )
         if task["type"] == "code":
             current_code = code

--- a/vision_agent/agent/vision_agent_v2.py
+++ b/vision_agent/agent/vision_agent_v2.py
@@ -230,7 +230,7 @@ def run_plan(
             user_req,
             task["instruction"],
             current_code,
-            write_code if task["type"] == "code" else write_test,  # type: ignore
+            write_code if task["type"] == "code" else write_test,
             coder,
             tool_info,
             exec,

--- a/vision_agent/agent/vision_agent_v2_prompt.py
+++ b/vision_agent/agent/vision_agent_v2_prompt.py
@@ -37,11 +37,13 @@ Based on the context and the tools you have available, write a plan of subtasks 
 - For each subtask, you should provide a short instruction on what to do. Ensure the subtasks are large enough to be meaningful, encompassing multiple lines of code.
 - You do not need to have the agent rewrite any tool functionality you already have, you should instead instruct it to utilize one or more of those tools in each subtask.
 - You can have agents either write coding tasks, to code some functionality or testing tasks to test previous functionality.
+- If a current plan exists, examine each item in the plan to determine if it was successful. If there was an item that failed, i.e. 'success': False, then you should rewrite that item and all subsequent items to ensure that the rewritten plan is successful.
 
 Output a list of jsons in the following format:
 
 ```json
 {{
+    "user_req": str, # "a summarized version of the user requirement"
     "plan":
         [
             {{

--- a/vision_agent/agent/vision_agent_v2_prompt.py
+++ b/vision_agent/agent/vision_agent_v2_prompt.py
@@ -1,3 +1,8 @@
+USER_REQ_CONTEXT = """
+## User Requirement
+{user_requirement}
+"""
+
 USER_REQ_SUBTASK_CONTEXT = """
 ## User Requirement
 {user_requirement}
@@ -6,11 +11,16 @@ USER_REQ_SUBTASK_CONTEXT = """
 {subtask}
 """
 
-USER_REQ_CONTEXT = """
+USER_REQ_SUBTASK_WM_CONTEXT = """
 ## User Requirement
 {user_requirement}
-"""
 
+## Current Subtask
+{subtask}
+
+## Previous Task
+{working_memory}
+"""
 
 PLAN = """
 # Context
@@ -61,8 +71,9 @@ CODE = """
 {code}
 
 # Constraints
-- Write a function that accomplishes the User Requirement. You are supplied code from a previous task, feel free to copy over that code into your own implementation if you need it.
-- Always prioritize using pre-defined tools or code for the same functionality. You have access to all these tools through the `from vision_agent.tools.tools_v2 import *` import.
+- Write a function that accomplishes the 'User Requirement'. You are supplied code from a previous task under 'Previous Code', feel free to copy over that code into your own implementation if you need it.
+- Always prioritize using pre-defined tools or code for the same functionality from 'Tool Info for Current Subtask'. You have access to all these tools through the `from vision_agent.tools.tools_v2 import *` import.
+- You may recieve previous trials and errors under 'Previous Task', this is code, output and reflections from previous tasks. You can use these to avoid running in to the same issues when writing your code.
 - Write clean, readable, and well-documented code.
 
 # Output
@@ -102,6 +113,7 @@ def add(a: int, b: int) -> int:
 
 
 PREV_CODE_CONTEXT = """
+[previous impl]
 ```python
 {code}
 ```
@@ -112,18 +124,20 @@ PREV_CODE_CONTEXT = """
 
 
 PREV_CODE_CONTEXT_WITH_REFLECTION = """
+[reflection on previous impl]
+{reflection}
+
+[new impl]
 ```python
 {code}
 ```
 
-[previous output]
+[new output]
 {result}
 
-[reflection on previous impl]
-{reflection}
 """
 
-
+# don't need [previous impl] because it will come from PREV_CODE_CONTEXT or PREV_CODE_CONTEXT_WITH_REFLECTION
 DEBUG = """
 [example]
 Here is an example of debugging with reflection.
@@ -133,7 +147,6 @@ Here is an example of debugging with reflection.
 [context]
 {context}
 
-[previous impl]
 {previous_impl}
 
 [instruction]
@@ -158,7 +171,7 @@ TEST = """
 {code}
 
 # Constraints
-- Write code to test the functionality of the provided code according to the Current Subtask. If you cannot test the code, then write code to visualize the result by calling the code.
+- Write code to test the functionality of the provided code according to the 'Current Subtask'. If you cannot test the code, then write code to visualize the result by calling the code.
 - Always prioritize using pre-defined tools for the same functionality.
 - Write clean, readable, and well-documented code.
 

--- a/vision_agent/llm/llm.py
+++ b/vision_agent/llm/llm.py
@@ -34,7 +34,7 @@ class OpenAILLM(LLM):
 
     def __init__(
         self,
-        model_name: str = "gpt-4-turbo",
+        model_name: str = "gpt-4o",
         api_key: Optional[str] = None,
         json_mode: bool = False,
         system_prompt: Optional[str] = None,

--- a/vision_agent/utils/__init__.py
+++ b/vision_agent/utils/__init__.py
@@ -1,3 +1,3 @@
 from .execute import Execute
-from .sim import Sim
+from .sim import Sim, load_sim, merge_sim
 from .video import extract_frames_from_video


### PR DESCRIPTION
Adding the remaining two items, long term memory and feedback, for the programming Vision Agent. Tried to make the vision agent more stateless. Calling `chat_with_workflow` returns a lot of stuff now so that the agent doesn't have to hold on to it as state:


`working_memory` is the trial and error reflections the model creates when debugging failed code. You can obtain this and use it as long term memory for future usage:

```python
output = agent.chat_with_workflow([{"role": "user", "content": "..."}])
wm = output["working_memory"]

# can save and load it
wm.save("working_mem")
wm = va.utils.load_sim("working_mem")

# merge with existing long term memory
new_ltm = va.utils.merge_sim(wm, ltm)

# can use working memory as long term memory
agent = va.agent.VisionAgentV2(long_term_memory=new_ltm)
```

If a subtask in the plan fails, it will return the partially completed code and plan early. You can pass a partially completed plan/conversation back to the agent to finish:

```python
output = agent.chat_with_workflow([{"role": "user", "content": "can you code this?"}])

output = agent.chat_with_workflow(
    [{
        "role": "user",
        "content": "can you code this?"
    }, {
        "role": "assistant",
        "content": output["code"],
    }, {
        "role": "user",
        "content": "No, can you use this library?"
    }],
    plan=output["plan"],
)
```

Or if you want to converse with the agent (passing the old plan back is optional and probably only useful if some part of the original plan failed). This way the chat itself stays stateless, and you can track the conversation/plan.