### PR TITLE
Minor changes to support benchmarking

### DIFF
--- a/examples/mask_app/app.py
+++ b/examples/mask_app/app.py
@@ -1,7 +1,8 @@
 import cv2
-import streamlit as st
 from PIL import Image
 from streamlit_drawable_canvas import st_canvas
+
+import streamlit as st
 
 st.title("Image Segmentation Mask App")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1145,13 +1145,13 @@ test = ["ipykernel", "pre-commit", "pytest (<8)", "pytest-cov", "pytest-timeout"
 
 [[package]]
 name = "langsmith"
-version = "0.1.75"
+version = "0.1.77"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.1.75-py3-none-any.whl", hash = "sha256:d08b08dd6b3fa4da170377f95123d77122ef4c52999d10fff4ae08ff70d07aed"},
-    {file = "langsmith-0.1.75.tar.gz", hash = "sha256:61274e144ea94c297dd78ce03e6dfae18459fe9bd8ab5094d61a0c4816561279"},
+    {file = "langsmith-0.1.77-py3-none-any.whl", hash = "sha256:2202cc21b1ed7e7b9e5d2af2694be28898afa048c09fdf09f620cbd9301755ae"},
+    {file = "langsmith-0.1.77.tar.gz", hash = "sha256:4ace09077a9a4e412afeb4b517ca68e7de7b07f36e4792dc8236ac5207c0c0c7"},
 ]
 
 [package.dependencies]

--- a/vision_agent/agent/vision_agent_prompts.py
+++ b/vision_agent/agent/vision_agent_prompts.py
@@ -179,6 +179,8 @@ This is the documentation for the functions you have access to. You may call any
 8. DO NOT use try except block to handle the error, let the error be raised if the code is incorrect.
 9. DO NOT import the testing function as it will available in the testing environment.
 10. Print the output of the function that is being tested.
+11. Use the output of the function that is being tested as the return value of the testing function.
+12. Run the testing function in the end and don't assign a variable to its output.
 """
 
 

--- a/vision_agent/utils/execute.py
+++ b/vision_agent/utils/execute.py
@@ -426,11 +426,11 @@ class E2BCodeInterpreter(CodeInterpreter):
             """
 import platform
 import sys
-import pkg_resources
+import importlib.metadata
 
 print(f"Python version: {sys.version}")
 print(f"OS version: {platform.system()} {platform.release()} ({platform.architecture()})")
-va_version = pkg_resources.get_distribution("vision-agent").version
+va_version = importlib.metadata.version("vision-agent")
 print(f"Vision Agent version: {va_version}")"""
         )
         sys_versions = "\n".join(result.logs.stdout)

--- a/vision_agent/utils/execute.py
+++ b/vision_agent/utils/execute.py
@@ -2,7 +2,6 @@ import abc
 import atexit
 import base64
 import copy
-import json
 import logging
 import os
 import platform

--- a/vision_agent/utils/execute.py
+++ b/vision_agent/utils/execute.py
@@ -2,6 +2,7 @@ import abc
 import atexit
 import base64
 import copy
+import json
 import logging
 import os
 import platform
@@ -308,6 +309,21 @@ class Execution(BaseModel):
         Returns whether the execution was successful.
         """
         return self.error is None
+
+    def get_main_result(self) -> Optional[Result]:
+        """
+        Get the main result of the execution.
+        An execution may have multiple results, e.g. intermediate outputs. The main result is the last output of the cell execution.
+        """
+        if not self.success:
+            _LOGGER.info("Result is not available as the execution was not successful.")
+            return None
+        if not self.results or not any(res.is_main_result for res in self.results):
+            _LOGGER.info("Execution was successful but there is no main result.")
+            return None
+        main_result = self.results[-1]
+        assert main_result.is_main_result, "The last result should be the main result."
+        return main_result
 
     def to_json(self) -> str:
         """


### PR DESCRIPTION
Minor changes to support benchmarking
1. Tweak the tester prompt to return the output in a testing function
2. Add a `get_main_result()` to `Execution` class
3. Update langsmith to the latest version