### PR TITLE
Capture model tool call trace in the notebook execution result

### DIFF
--- a/vision_agent/tools/tool_utils.py
+++ b/vision_agent/tools/tool_utils.py
@@ -66,7 +66,9 @@ def send_inference_request(
         # TODO: consider making the response schema the same between below two sources
         return resp if "TOOL_ENDPOINT_AUTH" in os.environ else resp["data"]  # type: ignore
     finally:
-        display({MimeType.APPLICATION_JSON: tool_call_trace.model_dump()}, raw=True)
+        trace = tool_call_trace.model_dump()
+        trace["type"] = "tool_call"
+        display({MimeType.APPLICATION_JSON: trace}, raw=True)
 
 
 def _create_requests_session(

--- a/vision_agent/utils/exceptions.py
+++ b/vision_agent/utils/exceptions.py
@@ -13,6 +13,15 @@ For more information, see https://landing-ai.github.io/landingai-python/landinga
         return self.message
 
 
+class RemoteToolCallFailed(Exception):
+    """Exception raised when an error occurs during a tool call."""
+
+    def __init__(self, tool_name: str, status_code: int, message: str):
+        self.message = (
+            f"""Tool call ({tool_name}) failed due to {status_code} - {message}"""
+        )
+
+
 class RemoteSandboxError(Exception):
     """Exception related to remote sandbox."""
 

--- a/vision_agent/utils/execute.py
+++ b/vision_agent/utils/execute.py
@@ -277,6 +277,17 @@ class Error(BaseModel):
         text = "\n".join(self.traceback_raw)
         return _remove_escape_and_color_codes(text) if return_clean_text else text
 
+    @staticmethod
+    def from_exception(e: Exception) -> "Error":
+        """
+        Creates an Error object from an exception.
+        """
+        return Error(
+            name=e.__class__.__name__,
+            value=str(e),
+            traceback_raw=traceback.format_exception(type(e), e, e.__traceback__),
+        )
+
 
 class Execution(BaseModel):
     """


### PR DESCRIPTION
Capture and save the model tool call trace in the notebook execution result.
Example captured result in json format:
```
>>> execution.results[0]["application/json"]
{
  "endpoint_url": "https://api.staging.landing.ai/v1/agent/model/tools",
  "type": "tool_call",
  "request": {
    "prompt": "resistor",
    "image": "x9IBVpht2cTBCVeWJYkpX6udUS7cAsov+WUhoOh8i3xI....",
    "tool": "open_vocab_detection",
    "kwargs": {
      "box_threshold": 0.1,
      "iou_threshold": 0.1
    },
    "runtime_tag": "local_dev"
  },
  "response": {
    "data": {
      "bboxes": [....],
      "labels": [
        "resistor",
        "resistor",
        "resistor",
        "resistor",
        "resistor",
        "resistor"
      ],
      "scores": [
        0.19836127758026123,
        0.13876622915267944,
        0.12910357117652893,
        0.1203366070985794,
        0.11757179349660873,
        0.10860796272754669
      ],
      "count": 6
    }
  },
  "error": null
}
```