### PR TITLE
fix: `save_video` encoding should be `X264`

### DIFF
--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -1069,7 +1069,7 @@ def save_video(
         ).name
 
     height, width, layers = frames[0].shape if frames else (0, 0, 0)
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # type: ignore
+    fourcc = cv2.VideoWriter_fourcc(*"X264")  # type: ignore
     video = cv2.VideoWriter(output_video_path, fourcc, fps, (width, height))
     for frame in frames:
         video.write(cv2.cvtColor(frame, cv2.COLOR_RGB2BGR))


### PR DESCRIPTION
The video cannot be played in the browser because the video encoding should be X264.

Slack thread: https://landingai.slack.com/archives/C07896KN3L0/p1722553166203759

Verified locally that the video can be played now:
<img width="550" alt="image" src="https://github.com/user-attachments/assets/483997a8-e7f4-4a6a-b33b-9a1cb16d0ced">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207947616642871