### PR TITLE
fix: remove the code execution result from logs in `pick_plan`

### DIFF
--- a/vision_agent/agent/vision_agent_coder.py
+++ b/vision_agent/agent/vision_agent_coder.py
@@ -93,7 +93,7 @@ def format_plans(plans: Dict[str, Any]) -> str:
 
 
 def extract_image(
-    media: Optional[Sequence[Union[str, Path]]]
+    media: Optional[Sequence[Union[str, Path]]],
 ) -> Optional[Sequence[Union[str, Path]]]:
     if media is None:
         return None
@@ -186,7 +186,7 @@ def pick_plan(
                 if tool_output.success
                 else "Code execution failed"
             ),
-            "payload": tool_output.to_json(),
+            # "payload": tool_output.to_json(),
             "status": "completed" if tool_output.success else "failed",
         }
     )
@@ -211,6 +211,9 @@ def pick_plan(
             }
         )
         code = extract_code(model(prompt))
+        tool_output = code_interpreter.exec_isolation(
+            DefaultImports.prepend_imports(code)
+        )
         log_progress(
             {
                 "type": "log",
@@ -220,12 +223,9 @@ def pick_plan(
                     else "Code execution failed"
                 ),
                 "code": DefaultImports.prepend_imports(code),
-                "payload": tool_output.to_json(),
+                # "payload": tool_output.to_json(),
                 "status": "completed" if tool_output.success else "failed",
             }
-        )
-        tool_output = code_interpreter.exec_isolation(
-            DefaultImports.prepend_imports(code)
         )
         tool_output_str = ""
         if len(tool_output.logs.stdout) > 0:

--- a/vision_agent/agent/vision_agent_coder.py
+++ b/vision_agent/agent/vision_agent_coder.py
@@ -186,6 +186,7 @@ def pick_plan(
                 if tool_output.success
                 else "Code execution failed"
             ),
+            "code": DefaultImports.prepend_imports(code),
             # "payload": tool_output.to_json(),
             "status": "completed" if tool_output.success else "failed",
         }


### PR DESCRIPTION
1. remove the code execution result from logs for `pick_plan`, otherwise the logs would be too large
2. exchange the sequence of one log when the first try failed in `pick_plan`, otherwise the retry would always show "Code execution failed"

Tested against the e2b backend
<img width="2210" alt="image" src="https://github.com/user-attachments/assets/2355b114-91e4-4944-b77c-044a7238f6e4">

The responseBody size is much smaller.
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/cac6892f-818c-4f25-a320-1bd25fe871ae">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207985513691304