### PR TITLE
minor fix for ocr

### DIFF
--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -312,6 +312,8 @@ def ocr(image: np.ndarray) -> List[Dict[str, Any]]:
 
     pil_image = Image.fromarray(image).convert("RGB")
     image_size = pil_image.size[::-1]
+    if image_size[0] < 1 and image_size[1] < 1:
+        return []
     image_buffer = io.BytesIO()
     pil_image.save(image_buffer, format="PNG")
     buffer_bytes = image_buffer.getvalue()


### PR DESCRIPTION
When doing a tasks such as license plate detection, detected areas will be cropped and then fed to OCR model, but OCR model occasionally crashes if the cropped region is too small or out of bounds of the image. This makes it so the model doesn't have to debug this issue.