### PR TITLE
feat: customized_tool_names param to VisionAgentCoder

### DIFF
--- a/vision_agent/tools/__init__.py
+++ b/vision_agent/tools/__init__.py
@@ -3,10 +3,12 @@ from typing import Callable, List, Optional
 from .meta_tools import META_TOOL_DOCSTRING, florencev2_fine_tuning
 from .prompts import CHOOSE_PARAMS, SYSTEM_PROMPT
 from .tools import (
+    FUNCTION_TOOLS,
     TOOL_DESCRIPTIONS,
     TOOL_DOCSTRING,
     TOOLS,
     TOOLS_DF,
+    UTIL_TOOLS,
     UTILITIES_DOCSTRING,
     blip_image_caption,
     clip,
@@ -18,10 +20,11 @@ from .tools import (
     extract_frames,
     florencev2_image_caption,
     florencev2_object_detection,
-    florencev2_roberta_vqa,
     florencev2_ocr,
+    florencev2_roberta_vqa,
     generate_pose_image,
     generate_soft_edge_image,
+    get_tool_descriptions_by_names,
     get_tool_documentation,
     git_vqa_v2,
     grounding_dino,

--- a/vision_agent/tools/tool_utils.py
+++ b/vision_agent/tools/tool_utils.py
@@ -127,6 +127,29 @@ def get_tool_descriptions(funcs: List[Callable[..., Any]]) -> str:
     return descriptions
 
 
+def get_tool_descriptions_by_names(
+    tool_name: List[str],
+    funcs: List[Callable[..., Any]],
+    util_funcs: List[
+        Callable[..., Any]
+    ],  # util_funcs will always be added to the list of functions
+) -> str:
+
+    invalid_names = [
+        name for name in tool_name if name not in {func.__name__ for func in funcs}
+    ]
+
+    if invalid_names:
+        raise ValueError(f"Invalid customized tool names: {', '.join(invalid_names)}")
+
+    filtered_funcs = (
+        funcs
+        if not tool_name
+        else [func for func in funcs if func.__name__ in tool_name]
+    )
+    return get_tool_descriptions(filtered_funcs + util_funcs)
+
+
 def get_tools_df(funcs: List[Callable[..., Any]]) -> pd.DataFrame:
     data: Dict[str, List[str]] = {"desc": [], "doc": []}
 

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -2,33 +2,34 @@ import io
 import json
 import logging
 import tempfile
-from pathlib import Path
 from importlib import resources
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import cv2
-import requests
 import numpy as np
-from pytube import YouTube  # type: ignore
+import requests
 from moviepy.editor import ImageSequenceClip
 from PIL import Image, ImageDraw, ImageFont
 from pillow_heif import register_heif_opener  # type: ignore
+from pytube import YouTube  # type: ignore
 
 from vision_agent.tools.tool_utils import (
-    send_inference_request,
     get_tool_descriptions,
+    get_tool_descriptions_by_names,
     get_tool_documentation,
     get_tools_df,
+    send_inference_request,
 )
 from vision_agent.utils import extract_frames_from_video
 from vision_agent.utils.execute import FileSerializer, MimeType
 from vision_agent.utils.image_utils import (
     b64_to_pil,
+    convert_quad_box_to_bbox,
     convert_to_b64,
     denormalize_bbox,
     get_image_size,
     normalize_bbox,
-    convert_quad_box_to_bbox,
     rle_decode,
 )
 
@@ -1285,7 +1286,17 @@ def overlay_heat_map(
     return np.array(combined)
 
 
-TOOLS = [
+UTIL_TOOLS = [
+    save_json,
+    load_image,
+    save_image,
+    save_video,
+    overlay_bounding_boxes,
+    overlay_segmentation_masks,
+    overlay_heat_map,
+]
+
+FUNCTION_TOOLS = [
     owl_v2,
     grounding_sam,
     extract_frames,
@@ -1305,15 +1316,11 @@ TOOLS = [
     generate_pose_image,
     closest_mask_distance,
     closest_box_distance,
-    save_json,
-    load_image,
-    save_image,
-    save_video,
-    overlay_bounding_boxes,
-    overlay_segmentation_masks,
-    overlay_heat_map,
     template_match,
 ]
+
+TOOLS = FUNCTION_TOOLS + UTIL_TOOLS
+
 TOOLS_DF = get_tools_df(TOOLS)  # type: ignore
 TOOL_DESCRIPTIONS = get_tool_descriptions(TOOLS)  # type: ignore
 TOOL_DOCSTRING = get_tool_documentation(TOOLS)  # type: ignore

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -19,11 +19,8 @@ from vision_agent.tools.tool_utils import (
     get_tool_descriptions_by_names,
     get_tool_documentation,
     get_tools_df,
-<<<<<<< HEAD
-    send_inference_request,
-=======
     get_tools_info,
->>>>>>> 58115951f8a050c9f9f7be2012efe97ec00498ed
+    send_inference_request,
 )
 from vision_agent.utils import extract_frames_from_video
 from vision_agent.utils.execute import FileSerializer, MimeType


### PR DESCRIPTION
Allow user to input `customized_tool_names` to `VisionAgentCoder` so user and limit and customize what tool to use. 

The implementation is non-destructive, it only changes input of `write_plans` (so planner only uses provided `customized_tool_names` + a list of util tools (such as `save_image`). the rest is still up to VisionAgentCoder. 

**This means the tool user pick is not mandatory, VisionAgentCoder might still ignore the `customized_tool_names` if it  doesn't think it solves the issue, even though it is the only choice it has**

### Test Case 1: default to all tools if `customized_tool_names` not provided
<img width="1379" alt="Screenshot 2024-08-26 at 18 04 43" src="https://github.com/user-attachments/assets/a742d424-9ca5-42e7-938b-988147075626">

### Test Case 2: only use tools from `customized_tool_names` if provided
<img width="1374" alt="Screenshot 2024-08-26 at 18 05 26" src="https://github.com/user-attachments/assets/d72fdcb3-51c9-4c5a-be1c-52ae8b01a430">

### Test Case 3: if provided tool name that does not exist yet, throw error
<img width="1402" alt="Screenshot 2024-08-26 at 18 05 10" src="https://github.com/user-attachments/assets/c22edc75-8447-46fc-9380-2925ee14bdc7">



