### PR TITLE
feat: revert e2b template back to va-sandbox

### DIFF
--- a/vision_agent/utils/execute.py
+++ b/vision_agent/utils/execute.py
@@ -532,7 +532,7 @@ print(f"Vision Agent version: {va_version}")"""
 
     @staticmethod
     def _new_e2b_interpreter_impl(*args, **kwargs) -> E2BCodeInterpreterImpl:  # type: ignore
-        template_name = os.environ.get("E2B_TEMPLATE_NAME", "nx3fagq7sgdliww9cvm3")
+        template_name = os.environ.get("E2B_TEMPLATE_NAME", "va-sandbox")
         _LOGGER.info(
             f"Creating a new E2BCodeInterpreter using template: {template_name}"
         )


### PR DESCRIPTION
According to E2B team, they have fixed the connection issue. So we can revert back to the production template and use GHA to build the template.