### PR TITLE
feat: use media url directly in both LMM and code sandbox

### DIFF
--- a/vision_agent/agent/vision_agent_coder.py
+++ b/vision_agent/agent/vision_agent_coder.py
@@ -718,7 +718,12 @@ class VisionAgentCoder(Agent):
             for chat_i in chat:
                 if "media" in chat_i:
                     for media in chat_i["media"]:
-                        media = media if type(media) is str and media.startswith(("http", "https")) else code_interpreter.upload_file(media)
+                        media = (
+                            media
+                            if type(media) is str
+                            and media.startswith(("http", "https"))
+                            else code_interpreter.upload_file(media)
+                        )
                         chat_i["content"] += f" Media name {media}"  # type: ignore
                         media_list.append(media)
 

--- a/vision_agent/agent/vision_agent_coder.py
+++ b/vision_agent/agent/vision_agent_coder.py
@@ -753,9 +753,7 @@ class VisionAgentCoder(Agent):
             plans = write_plans(
                 int_chat,
                 T.get_tool_descriptions_by_names(
-                    customized_tool_names,
-                    T.FUNCTION_TOOLS,
-                    T.UTIL_TOOLS,  # type: ignore
+                    customized_tool_names, T.FUNCTION_TOOLS, T.UTIL_TOOLS  # type: ignore
                 ),
                 format_memory(working_memory),
                 self.planner,

--- a/vision_agent/agent/vision_agent_coder.py
+++ b/vision_agent/agent/vision_agent_coder.py
@@ -718,7 +718,6 @@ class VisionAgentCoder(Agent):
             for chat_i in chat:
                 if "media" in chat_i:
                     for media in chat_i["media"]:
-                        media = code_interpreter.upload_file(media)
                         chat_i["content"] += f" Media name {media}"  # type: ignore
                         media_list.append(media)
 
@@ -754,7 +753,9 @@ class VisionAgentCoder(Agent):
             plans = write_plans(
                 int_chat,
                 T.get_tool_descriptions_by_names(
-                    customized_tool_names, T.FUNCTION_TOOLS, T.UTIL_TOOLS  # type: ignore
+                    customized_tool_names,
+                    T.FUNCTION_TOOLS,
+                    T.UTIL_TOOLS,  # type: ignore
                 ),
                 format_memory(working_memory),
                 self.planner,

--- a/vision_agent/agent/vision_agent_coder.py
+++ b/vision_agent/agent/vision_agent_coder.py
@@ -718,6 +718,7 @@ class VisionAgentCoder(Agent):
             for chat_i in chat:
                 if "media" in chat_i:
                     for media in chat_i["media"]:
+                        media = media if type(media) is str and media.startswith(("http", "https")) else code_interpreter.upload_file(media)
                         chat_i["content"] += f" Media name {media}"  # type: ignore
                         media_list.append(media)
 

--- a/vision_agent/lmm/lmm.py
+++ b/vision_agent/lmm/lmm.py
@@ -144,9 +144,11 @@ class OpenAILMM(LMM):
                         {
                             "type": "image_url",
                             "image_url": {
-                                "url": encoded_media
-                                if encoded_media.startswith(("http", "https"))
-                                else f"data:image/png;base64,{encoded_media}",
+                                "url": (
+                                    encoded_media
+                                    if encoded_media.startswith(("http", "https"))
+                                    else f"data:image/png;base64,{encoded_media}"
+                                ),
                                 "detail": "low",
                             },
                         },

--- a/vision_agent/lmm/lmm.py
+++ b/vision_agent/lmm/lmm.py
@@ -30,6 +30,10 @@ def encode_image_bytes(image: bytes) -> str:
 
 
 def encode_media(media: Union[str, Path]) -> str:
+    if type(media) is str and media.startswith(("http", "https")):
+        if media.endswith(".mp4"):
+            return media[:-4] + ".png"
+        return media
     extension = "png"
     extension = Path(media).suffix
     if extension.lower() not in {
@@ -138,7 +142,9 @@ class OpenAILMM(LMM):
                         {
                             "type": "image_url",
                             "image_url": {
-                                "url": f"data:image/png;base64,{encoded_media}",
+                                "url": encoded_media
+                                if encoded_media.startswith(("http", "https"))
+                                else f"data:image/png;base64,{encoded_media}",
                                 "detail": "low",
                             },
                         },

--- a/vision_agent/lmm/lmm.py
+++ b/vision_agent/lmm/lmm.py
@@ -33,7 +33,7 @@ def encode_media(media: Union[str, Path]) -> str:
     if type(media) is str and media.startswith(("http", "https")):
         # for mp4 video url, we assume there is a same url but ends with png
         # vision-agent-ui will upload this png when uploading the video
-        if media.endswith((".mp4", "mov")):
+        if media.endswith((".mp4", "mov")) and media.find('vision-agent-dev.s3') != -1:
             return media[:-4] + ".png"
         return media
     extension = "png"

--- a/vision_agent/lmm/lmm.py
+++ b/vision_agent/lmm/lmm.py
@@ -33,7 +33,7 @@ def encode_media(media: Union[str, Path]) -> str:
     if type(media) is str and media.startswith(("http", "https")):
         # for mp4 video url, we assume there is a same url but ends with png
         # vision-agent-ui will upload this png when uploading the video
-        if media.endswith((".mp4", "mov")) and media.find('vision-agent-dev.s3') != -1:
+        if media.endswith((".mp4", "mov")) and media.find("vision-agent-dev.s3") != -1:
             return media[:-4] + ".png"
         return media
     extension = "png"

--- a/vision_agent/lmm/lmm.py
+++ b/vision_agent/lmm/lmm.py
@@ -31,7 +31,9 @@ def encode_image_bytes(image: bytes) -> str:
 
 def encode_media(media: Union[str, Path]) -> str:
     if type(media) is str and media.startswith(("http", "https")):
-        if media.endswith(".mp4"):
+        # for mp4 video url, we assume there is a same url but ends with png
+        # vision-agent-ui will upload this png when uploading the video
+        if media.endswith((".mp4", "mov")):
             return media[:-4] + ".png"
         return media
     extension = "png"
@@ -396,7 +398,6 @@ class OllamaLMM(LMM):
         tmp_kwargs = self.kwargs | kwargs
         data.update(tmp_kwargs)
         if "stream" in tmp_kwargs and tmp_kwargs["stream"]:
-
             json_data = json.dumps(data)
 
             def f() -> Iterator[Optional[str]]:
@@ -430,7 +431,6 @@ class OllamaLMM(LMM):
         media: Optional[List[Union[str, Path]]] = None,
         **kwargs: Any,
     ) -> Union[str, Iterator[Optional[str]]]:
-
         url = f"{self.url}/generate"
         data: Dict[str, Any] = {
             "model": self.model_name,
@@ -445,7 +445,6 @@ class OllamaLMM(LMM):
         tmp_kwargs = self.kwargs | kwargs
         data.update(tmp_kwargs)
         if "stream" in tmp_kwargs and tmp_kwargs["stream"]:
-
             json_data = json.dumps(data)
 
             def f() -> Iterator[Optional[str]]:

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -1273,8 +1273,6 @@ def load_image(image_path: str) -> np.ndarray:
             # Download the image and save it to the temporary file
             with urllib.request.urlopen(image_path) as response:
                 tmp_file.write(response.read())
-            _LOGGER.info(f"{image_path} saved to {tmp_file.name}")
-            print(f"{image_path} saved to {tmp_file.name}")
             image_path = tmp_file.name
     image = Image.open(image_path).convert("RGB")
     return np.array(image)

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -1222,6 +1222,13 @@ def extract_frames(
             video_file_path = video.download(output_path=temp_dir)
 
             return extract_frames_from_video(video_file_path, fps)
+    elif str(video_uri).startswith(("http", "https")):
+        _, image_suffix = os.path.splitext(video_uri)
+        with tempfile.NamedTemporaryFile(delete=False, suffix=image_suffix) as tmp_file:
+            # Download the video and save it to the temporary file
+            with urllib.request.urlopen(str(video_uri)) as response:
+                tmp_file.write(response.read())
+            return extract_frames_from_video(tmp_file.name, fps)
 
     return extract_frames_from_video(str(video_uri), fps)
 


### PR DESCRIPTION
We used to always use the local media:

- encode it as base64 and talk with OpenAI
- upload it to the code interpreter before execution

This PR adds the support to directly use the media URL
1. [OpenAI](https://platform.openai.com/docs/guides/vision?lang=curl) supports both base64 and URL format of the image
2. Added the support to download from URL in the tool `load_image` and `extract_frames`. Although the `moviepy` can directly use the URL, but after testing, looks like download it first seems more stable.
3. During `write_plan`, we need to feed the LLM one frame of the video, we assume there is a same url that only differs in the suffix. (https://xxxxx.mp4 -> https://xxxxx.png)

Local run:

- image

<img width="2212" alt="image" src="https://github.com/user-attachments/assets/51005f6c-7dae-4d98-8235-a07cd8e41334">


- video
<img width="2249" alt="image" src="https://github.com/user-attachments/assets/1507557c-de35-4f4e-a753-6a0e238a26e3">
