### PR TITLE
feat: add files to tool call trace

### DIFF
--- a/vision_agent/tools/tool_utils.py
+++ b/vision_agent/tools/tool_utils.py
@@ -1,3 +1,4 @@
+from base64 import b64encode
 import inspect
 import logging
 import os
@@ -27,6 +28,7 @@ class ToolCallTrace(BaseModel):
     request: MutableMapping[str, Any]
     response: MutableMapping[str, Any]
     error: Optional[Error]
+    files: Optional[List[Dict[str, str]]]
 
 
 def send_inference_request(
@@ -202,12 +204,21 @@ def _call_post(
     files: Optional[List[Tuple[Any, ...]]] = None,
     function_name: str = "unknown",
 ) -> Any:
+    files_in_b64 = None
+    if files:
+        files_in_b64 = [
+            {"video": b64encode(file[1]).decode("utf-8")}
+            if file[0] == "video"
+            else {"image": b64encode(file[0]).decode("utf-8")}
+            for file in files
+        ]
     try:
         tool_call_trace = ToolCallTrace(
             endpoint_url=url,
             request=payload,
             response={},
             error=None,
+            files=files_in_b64,
         )
 
         if files is not None:

--- a/vision_agent/tools/tool_utils.py
+++ b/vision_agent/tools/tool_utils.py
@@ -28,7 +28,7 @@ class ToolCallTrace(BaseModel):
     request: MutableMapping[str, Any]
     response: MutableMapping[str, Any]
     error: Optional[Error]
-    files: Optional[List[Dict[str, str]]]
+    files: Optional[List[tuple[str, str]]]
 
 
 def send_inference_request(
@@ -206,12 +206,7 @@ def _call_post(
 ) -> Any:
     files_in_b64 = None
     if files:
-        files_in_b64 = [
-            {"video": b64encode(file[1]).decode("utf-8")}
-            if file[0] == "video"
-            else {"image": b64encode(file[0]).decode("utf-8")}
-            for file in files
-        ]
+        files_in_b64 = [(file[0], b64encode(file[1]).decode("utf-8")) for file in files]
     try:
         tool_call_trace = ToolCallTrace(
             endpoint_url=url,


### PR DESCRIPTION
Some tools use the `files` param in the `send_inference_request`, which cannot be captured by the `ToolCallTrace`

```python
    buffer_bytes = frames_to_bytes(frames)
    files = [("video", buffer_bytes)]
    payload = {
        "prompts": [s.strip() for s in prompt.split(",")],
        "function_name": "florence2_sam2_video_tracking",
    }
    data: Dict[str, Any] = send_inference_request(
        payload, "florence2-sam2", files=files, v2=True
```

This PR adds the `files` in `ToolCallTrace`, which are the base64 encoded files, so we can capture the tool input files in downstream processing.

