### PR TITLE
feat: add OPENAI_API_KEY to e2b env

### DIFF
--- a/vision_agent/utils/execute.py
+++ b/vision_agent/utils/execute.py
@@ -706,7 +706,7 @@ class CodeInterpreterFactory:
         return instance
 
 
-def _get_e2b_env() -> Dict[str, str] | None:
+def _get_e2b_env() -> Union[Dict[str, str], None]:
     openai_api_key = os.getenv("OPENAI_API_KEY", "")
     anthropic_api_key = os.getenv("ANTHROPIC_API_KEY", "")
     if openai_api_key or anthropic_api_key:

--- a/vision_agent/utils/execute.py
+++ b/vision_agent/utils/execute.py
@@ -690,9 +690,11 @@ class CodeInterpreterFactory:
     ) -> CodeInterpreter:
         if not code_sandbox_runtime:
             code_sandbox_runtime = os.getenv("CODE_SANDBOX_RUNTIME", "local")
+        openai_api_key = os.getenv("OPENAI_API_KEY", "")
+        envs = {"OPENAI_API_KEY": openai_api_key} if openai_api_key else None
         if code_sandbox_runtime == "e2b":
             instance: CodeInterpreter = E2BCodeInterpreter(
-                timeout=_SESSION_TIMEOUT, remote_path=remote_path
+                timeout=_SESSION_TIMEOUT, remote_path=remote_path, envs=envs
             )
         elif code_sandbox_runtime == "local":
             instance = LocalCodeInterpreter(

--- a/vision_agent/utils/execute.py
+++ b/vision_agent/utils/execute.py
@@ -690,9 +690,8 @@ class CodeInterpreterFactory:
     ) -> CodeInterpreter:
         if not code_sandbox_runtime:
             code_sandbox_runtime = os.getenv("CODE_SANDBOX_RUNTIME", "local")
-        openai_api_key = os.getenv("OPENAI_API_KEY", "")
-        envs = {"OPENAI_API_KEY": openai_api_key} if openai_api_key else None
         if code_sandbox_runtime == "e2b":
+            envs = _get_e2b_env()
             instance: CodeInterpreter = E2BCodeInterpreter(
                 timeout=_SESSION_TIMEOUT, remote_path=remote_path, envs=envs
             )
@@ -705,6 +704,20 @@ class CodeInterpreterFactory:
                 f"Unsupported code sandbox runtime: {code_sandbox_runtime}. Supported runtimes: e2b, local"
             )
         return instance
+
+
+def _get_e2b_env() -> Dict[str, str] | None:
+    openai_api_key = os.getenv("OPENAI_API_KEY", "")
+    anthropic_api_key = os.getenv("ANTHROPIC_API_KEY", "")
+    if openai_api_key or anthropic_api_key:
+        envs = {}
+        if openai_api_key:
+            envs["OPENAI_API_KEY"] = openai_api_key
+        if anthropic_api_key:
+            envs["ANTHROPIC_API_KEY"] = anthropic_api_key
+    else:
+        envs = None
+    return envs
 
 
 def _parse_local_code_interpreter_outputs(outputs: List[Dict[str, Any]]) -> Execution:


### PR DESCRIPTION
see title
When running conversation, e2b needs the OPENAI_API_KEY to run `generate_vision_code`

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/198c4d78-5c76-4427-983b-587ab51de5a2">
