### PR TITLE
fix get_embedding in class AzureSim, passing self.emb_call instead of…

### DIFF
--- a/vision_agent/utils/sim.py
+++ b/vision_agent/utils/sim.py
@@ -125,7 +125,7 @@ class AzureSim(Sim):
             raise ValueError("key is required if no column 'embs' is present.")
 
         if sim_key is not None:
-            self.df["embs"] = self.df[sim_key].apply(lambda x: get_embedding(client, x))
+            self.df["embs"] = self.df[sim_key].apply(lambda x: get_embedding(self.emb_call, x))
 
 
 class OllamaSim(Sim):

--- a/vision_agent/utils/sim.py
+++ b/vision_agent/utils/sim.py
@@ -125,7 +125,9 @@ class AzureSim(Sim):
             raise ValueError("key is required if no column 'embs' is present.")
 
         if sim_key is not None:
-            self.df["embs"] = self.df[sim_key].apply(lambda x: get_embedding(self.emb_call, x))
+            self.df["embs"] = self.df[sim_key].apply(
+                lambda x: get_embedding(self.emb_call, x)
+            )
 
 
 class OllamaSim(Sim):


### PR DESCRIPTION
When using AzureVisionAgentCoder, I got error of `TypeError: 'AzureOpenAI' object is not callable`

![image](https://github.com/user-attachments/assets/0ada7200-b4e1-435c-b582-81b9ff20338c)

Fixed it with just a simple code change.
