### PR TITLE
fix: add `function_name` in tool_calls `payload` if it's missing

### DIFF
--- a/vision_agent/tools/tool_utils.py
+++ b/vision_agent/tools/tool_utils.py
@@ -208,18 +208,24 @@ def _call_post(
     if files:
         files_in_b64 = [(file[0], b64encode(file[1]).decode("utf-8")) for file in files]
     try:
-        tool_call_trace = ToolCallTrace(
-            endpoint_url=url,
-            request=payload,
-            response={},
-            error=None,
-            files=files_in_b64,
-        )
-
         if files is not None:
             response = session.post(url, data=payload, files=files)
         else:
             response = session.post(url, json=payload)
+
+        # make sure function_name is in the payload so we can display it
+        tool_call_trace_payload = (
+            payload
+            if "function_name" in payload
+            else {**payload, **{"function_name": function_name}}
+        )
+        tool_call_trace = ToolCallTrace(
+            endpoint_url=url,
+            request=tool_call_trace_payload,
+            response={},
+            error=None,
+            files=files_in_b64,
+        )
 
         if response.status_code != 200:
             tool_call_trace.error = Error(


### PR DESCRIPTION
`countgd_counting` and `countgd_example_based_counting` are using `send_task_inference_request` to call the model, which does not have `function_name` in the request payload. However, the UI needs this name to correctly show the tool calls trace.

This PR makes sure the `function_name` is in the tool_calls payload.

Local test:
<img width="2062" alt="image" src="https://github.com/user-attachments/assets/a08fbfae-8cb5-4be0-b035-7ac9f74bcb16">
