### PR TITLE
fix: remote path default to WORKSPACE, keep in sync with local path

### DIFF
--- a/vision_agent/utils/execute.py
+++ b/vision_agent/utils/execute.py
@@ -464,9 +464,7 @@ print(f"Vision Agent version: {va_version}")"""
         _LOGGER.info(
             f"E2BCodeInterpreter (sandbox id: {self.interpreter.sandbox_id}) initialized:\n{sys_versions}"
         )
-        self.remote_path = Path(
-            remote_path if remote_path is not None else "/home/user"
-        )
+        self.remote_path = Path(remote_path if remote_path is not None else WORKSPACE)
 
     def close(self, *args: Any, **kwargs: Any) -> None:
         try:


### PR DESCRIPTION
The Artifact path needs to be in sync between local and remote.

For local artifact, we always use "WORKSPACE/home/user"

But for e2b, the default upload path is "/home/user", which is not in sync with the local path. This may cause `FileNotFound` errors:
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/ca002892-15b5-4357-83b0-516c76846fa8">
