### PR TITLE
Fix for several issues with VisionAgent

### DIFF
--- a/tests/unit/test_meta_tools.py
+++ b/tests/unit/test_meta_tools.py
@@ -1,0 +1,73 @@
+from vision_agent.tools.meta_tools import (
+    Artifacts,
+    check_and_load_image,
+    use_object_detection_fine_tuning,
+)
+
+
+def test_check_and_load_image_none():
+    assert check_and_load_image("print('Hello, World!')") == []
+
+
+def test_check_and_load_image_one():
+    assert check_and_load_image("view_media_artifact(artifacts, 'image.jpg')") == [
+        "image.jpg"
+    ]
+
+
+def test_check_and_load_image_two():
+    code = "view_media_artifact(artifacts, 'image1.jpg')\nview_media_artifact(artifacts, 'image2.jpg')"
+    assert check_and_load_image(code) == ["image1.jpg", "image2.jpg"]
+
+
+def test_use_object_detection_fine_tuning_none():
+    artifacts = Artifacts("test")
+    code = "print('Hello, World!')"
+    artifacts["code"] = code
+    output = use_object_detection_fine_tuning(artifacts, "code", "123")
+    assert (
+        output == "[No function calls to replace with fine tuning id in artifact code]"
+    )
+    assert artifacts["code"] == code
+
+
+def test_use_object_detection_fine_tuning():
+    artifacts = Artifacts("test")
+    code = """florence2_phrase_grounding('one', image1)
+owl_v2_image('two', image2)
+florence2_sam2_image('three', image3)"""
+    expected_code = """florence2_phrase_grounding("one", image1, "123")
+owl_v2_image("two", image2, "123")
+florence2_sam2_image("three", image3, "123")"""
+    artifacts["code"] = code
+
+    output = use_object_detection_fine_tuning(artifacts, "code", "123")
+    assert 'florence2_phrase_grounding("one", image1, "123")' in output
+    assert 'owl_v2_image("two", image2, "123")' in output
+    assert 'florence2_sam2_image("three", image3, "123")' in output
+    assert artifacts["code"] == expected_code
+
+
+def test_use_object_detection_fine_tuning_twice():
+    artifacts = Artifacts("test")
+    code = """florence2_phrase_grounding('one', image1)
+owl_v2_image('two', image2)
+florence2_sam2_image('three', image3)"""
+    expected_code1 = """florence2_phrase_grounding("one", image1, "123")
+owl_v2_image("two", image2, "123")
+florence2_sam2_image("three", image3, "123")"""
+    expected_code2 = """florence2_phrase_grounding("one", image1, "456")
+owl_v2_image("two", image2, "456")
+florence2_sam2_image("three", image3, "456")"""
+    artifacts["code"] = code
+    output = use_object_detection_fine_tuning(artifacts, "code", "123")
+    assert 'florence2_phrase_grounding("one", image1, "123")' in output
+    assert 'owl_v2_image("two", image2, "123")' in output
+    assert 'florence2_sam2_image("three", image3, "123")' in output
+    assert artifacts["code"] == expected_code1
+
+    output = use_object_detection_fine_tuning(artifacts, "code", "456")
+    assert 'florence2_phrase_grounding("one", image1, "456")' in output
+    assert 'owl_v2_image("two", image2, "456")' in output
+    assert 'florence2_sam2_image("three", image3, "456")' in output
+    assert artifacts["code"] == expected_code2

--- a/tests/unit/test_va.py
+++ b/tests/unit/test_va.py
@@ -1,0 +1,52 @@
+from vision_agent.agent.vision_agent import parse_execution
+
+
+def test_parse_execution_zero():
+    code = "print('Hello, World!')"
+    assert parse_execution(code) == None
+
+
+def test_parse_execution_one():
+    code = "<execute_python>print('Hello, World!')</execute_python>"
+    assert parse_execution(code) == "print('Hello, World!')"
+
+
+def test_parse_execution_no_test_multi_plan_generate():
+    code = "<execute_python>generate_vision_code(artifacts, 'code.py', 'Generate code', ['image.png'])</execute_python>"
+    assert (
+        parse_execution(code, False)
+        == "generate_vision_code(artifacts, 'code.py', 'Generate code', ['image.png'], test_multi_plan=False)"
+    )
+
+
+def test_parse_execution_no_test_multi_plan_edit():
+    code = "<execute_python>edit_vision_code(artifacts, 'code.py', ['Generate code'], ['image.png'])</execute_python>"
+    assert (
+        parse_execution(code, False)
+        == "edit_vision_code(artifacts, 'code.py', ['Generate code'], ['image.png'])"
+    )
+
+
+def test_parse_execution_custom_tool_names_generate():
+    code = "<execute_python>generate_vision_code(artifacts, 'code.py', 'Generate code', ['image.png'])</execute_python>"
+    assert (
+        parse_execution(
+            code, test_multi_plan=False, customed_tool_names=["owl_v2_image"]
+        )
+        == "generate_vision_code(artifacts, 'code.py', 'Generate code', ['image.png'], test_multi_plan=False, custom_tool_names=['owl_v2_image'])"
+    )
+
+
+def test_prase_execution_custom_tool_names_edit():
+    code = "<execute_python>edit_vision_code(artifacts, 'code.py', ['Generate code'], ['image.png'])</execute_python>"
+    assert (
+        parse_execution(
+            code, test_multi_plan=False, customed_tool_names=["owl_v2_image"]
+        )
+        == "edit_vision_code(artifacts, 'code.py', ['Generate code'], ['image.png'], custom_tool_names=['owl_v2_image'])"
+    )
+
+
+def test_parse_execution_multiple_executes():
+    code = "<execute_python>print('Hello, World!')</execute_python><execute_python>print('Hello, World!')</execute_python>"
+    assert parse_execution(code) == "print('Hello, World!')\nprint('Hello, World!')"

--- a/tests/unit/test_va.py
+++ b/tests/unit/test_va.py
@@ -3,7 +3,7 @@ from vision_agent.agent.vision_agent import parse_execution
 
 def test_parse_execution_zero():
     code = "print('Hello, World!')"
-    assert parse_execution(code) == None
+    assert parse_execution(code) is None
 
 
 def test_parse_execution_one():

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -87,7 +87,7 @@ def run_conversation(orch: LMM, chat: List[Message]) -> Dict[str, Any]:
     return extract_json(orch([message], stream=False))  # type: ignore
 
 
-def run_code_action(
+def execute_code_action(
     code: str, code_interpreter: CodeInterpreter, artifact_remote_path: str
 ) -> Tuple[Execution, str]:
     result = code_interpreter.exec_isolation(
@@ -115,10 +115,33 @@ def parse_execution(
     return code
 
 
+def execute_user_code_action(
+    last_user_message: Message,
+    code_interpreter: CodeInterpreter,
+    artifact_remote_path: str,
+) -> Tuple[Optional[Execution], Optional[str]]:
+    user_result = None
+    user_obs = None
+
+    if last_user_message["role"] != "user":
+        return user_result, user_obs
+
+    last_user_content = cast(str, last_user_message.get("content", ""))
+
+    user_code_action = parse_execution(last_user_content, False)
+    if user_code_action is not None:
+        user_result, user_obs = execute_code_action(
+            user_code_action, code_interpreter, artifact_remote_path
+        )
+        if user_result.error:
+            user_obs += f"\n{user_result.error}"
+    return user_result, user_obs
+
+
 class VisionAgent(Agent):
     """Vision Agent is an agent that can chat with the user and call tools or other
     agents to generate code for it. Vision Agent uses python code to execute actions
-    for the user. Vision Agent is inspired by by OpenDev
+    for the user. Vision Agent is inspired by by OpenDevin
     https://github.com/OpenDevin/OpenDevin and CodeAct https://arxiv.org/abs/2402.01030
 
     Example
@@ -278,9 +301,23 @@ class VisionAgent(Agent):
             orig_chat.append({"role": "observation", "content": artifacts_loaded})
             self.streaming_message({"role": "observation", "content": artifacts_loaded})
 
-            finished = self.execute_user_code_action(
-                last_user_message, code_interpreter, remote_artifacts_path
+            user_result, user_obs = execute_user_code_action(
+                last_user_message, code_interpreter, str(remote_artifacts_path)
             )
+            finished = user_result is not None and user_obs is not None
+            if user_result is not None and user_obs is not None:
+                chat_elt: Message = {"role": "observation", "content": user_obs}
+                int_chat.append(chat_elt)
+                chat_elt["execution"] = user_result
+                orig_chat.append(chat_elt)
+                self.streaming_message(
+                    {
+                        "role": "observation",
+                        "content": user_obs,
+                        "execution": user_result,
+                        "finished": finished,
+                    }
+                )
 
             while not finished and iterations < self.max_iterations:
                 response = run_conversation(self.agent, int_chat)
@@ -322,7 +359,7 @@ class VisionAgent(Agent):
                     )
 
                 if code_action is not None:
-                    result, obs = run_code_action(
+                    result, obs = execute_code_action(
                         code_action, code_interpreter, str(remote_artifacts_path)
                     )
 
@@ -331,17 +368,17 @@ class VisionAgent(Agent):
                     if self.verbosity >= 1:
                         _LOGGER.info(obs)
 
-                    chat_elt: Message = {"role": "observation", "content": obs}
+                    obs_chat_elt: Message = {"role": "observation", "content": obs}
                     if media_obs and result.success:
-                        chat_elt["media"] = [
+                        obs_chat_elt["media"] = [
                             Path(code_interpreter.remote_path) / media_ob
                             for media_ob in media_obs
                         ]
 
                     # don't add execution results to internal chat
-                    int_chat.append(chat_elt)
-                    chat_elt["execution"] = result
-                    orig_chat.append(chat_elt)
+                    int_chat.append(obs_chat_elt)
+                    obs_chat_elt["execution"] = result
+                    orig_chat.append(obs_chat_elt)
                     self.streaming_message(
                         {
                             "role": "observation",
@@ -361,34 +398,6 @@ class VisionAgent(Agent):
             artifacts.load(self.local_artifacts_path)
             artifacts.save()
         return orig_chat, artifacts
-
-    def execute_user_code_action(
-        self,
-        last_user_message: Message,
-        code_interpreter: CodeInterpreter,
-        remote_artifacts_path: Path,
-    ) -> bool:
-        if last_user_message["role"] != "user":
-            return False
-        user_code_action = parse_execution(
-            cast(str, last_user_message.get("content", "")), False
-        )
-        if user_code_action is not None:
-            user_result, user_obs = run_code_action(
-                user_code_action, code_interpreter, str(remote_artifacts_path)
-            )
-            if self.verbosity >= 1:
-                _LOGGER.info(user_obs)
-            self.streaming_message(
-                {
-                    "role": "observation",
-                    "content": user_obs,
-                    "execution": user_result,
-                    "finished": True,
-                }
-            )
-            return True
-        return False
 
     def streaming_message(self, message: Dict[str, Any]) -> None:
         if self.callback_message:

--- a/vision_agent/agent/vision_agent_coder.py
+++ b/vision_agent/agent/vision_agent_coder.py
@@ -691,7 +691,7 @@ class VisionAgentCoder(Agent):
         chat: List[Message],
         test_multi_plan: bool = True,
         display_visualization: bool = False,
-        customized_tool_names: Optional[List[str]] = None,
+        custom_tool_names: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Chat with VisionAgentCoder and return intermediate information regarding the
         task.
@@ -707,8 +707,8 @@ class VisionAgentCoder(Agent):
                 with the first plan.
             display_visualization (bool): If True, it opens a new window locally to
                 show the image(s) created by visualization code (if there is any).
-            customized_tool_names (List[str]): A list of customized tools for agent to pick and use.
-                If not provided, default to full tool set from vision_agent.tools.
+            custom_tool_names (List[str]): A list of custom tools for the agent to pick
+                and use. If not provided, default to full tool set from vision_agent.tools.
 
         Returns:
             Dict[str, Any]: A dictionary containing the code, test, test result, plan,
@@ -760,7 +760,7 @@ class VisionAgentCoder(Agent):
             success = False
 
             plans = self._create_plans(
-                int_chat, customized_tool_names, working_memory, self.planner
+                int_chat, custom_tool_names, working_memory, self.planner
             )
 
             if test_multi_plan:

--- a/vision_agent/agent/vision_agent_coder_prompts.py
+++ b/vision_agent/agent/vision_agent_coder_prompts.py
@@ -270,42 +270,42 @@ Plan 1 - owl_v2_image:
 
 **Input Code Snippet**:
 ```python
-from vision_agent.tools import load_image, owl_v2_image 
+from vision_agent.tools import load_image, owl_v2_image
 
 def check_helmets(image_path):
     image = load_image(image_path)
     # Detect people and helmets, filter out the lowest confidence helmet score of 0.15
     detections = owl_v2_image("person, helmet", image, box_threshold=0.15)
     height, width = image.shape[:2]
-    
+
     # Separate people and helmets
     people = [d for d in detections if d['label'] == 'person']
     helmets = [d for d in detections if d['label'] == 'helmet']
-    
+
     people_with_helmets = 0
     people_without_helmets = 0
-    
+
     for person in people:
         person_x = (person['bbox'][0] + person['bbox'][2]) / 2
         person_y = person['bbox'][1]  # Top of the bounding box
-        
+
         helmet_found = False
         for helmet in helmets:
             helmet_x = (helmet['bbox'][0] + helmet['bbox'][2]) / 2
             helmet_y = (helmet['bbox'][1] + helmet['bbox'][3]) / 2
-            
+
             # Check if the helmet is within 20 pixels of the person's head. Unnormalize
             # the coordinates so we can better compare them.
             if (abs((helmet_x - person_x) * width) < 20 and
                 -5 < ((helmet_y - person_y) * height) < 20):
                 helmet_found = True
                 break
-        
+
         if helmet_found:
             people_with_helmets += 1
         else:
             people_without_helmets += 1
-    
+
     return {{
         "people_with_helmets": people_with_helmets,
         "people_without_helmets": people_without_helmets
@@ -319,7 +319,7 @@ def check_helmets(image_path):
 3. **Pseudocode Creation**: Write down the steps you will follow in pseudocode.
 4. **Code Generation**: Translate your pseudocode into executable Python code.
     4.1. Take in the media path as an argument and load with either `load_image` or `extract_frames_and_timestamps`.
-    4.2. Coordinates are always returned normalized from `vision_agent.tools`. 
+    4.2. Coordinates are always returned normalized from `vision_agent.tools`.
     4.3. Do not create dummy input or functions, the code must be usable if the user provides new media.
     4.4. Use unnormalized coordinates when comparing bounding boxes.
 """

--- a/vision_agent/agent/vision_agent_prompts.py
+++ b/vision_agent/agent/vision_agent_prompts.py
@@ -26,7 +26,9 @@ Here is the current conversation so far:
 
 **Instructions**:
 1. **Understand and Clarify**: Make sure you understand the task, ask clarifying questions if the task is not clear.
-2. **Output in JSON**: Respond in the following format in JSON:
+2. **Code Generation**: Only use code provided in the Documentation in your <execute_python> tags. Only use `edit_vision_code` to modify code written by `generate_vision_code`.
+3. **Execute**: Do only what the user asked you to do and no more. If you need to ask the user a question, set `let_user_respond` to `true`.
+4. **Output in JSON**: Respond in the following format in JSON:
 
 ```json
 {{"thoughts": <your thoughts>, "response": <your response to the user>, "let_user_respond": <a boolean whether or not to let the user respond>}}.
@@ -149,7 +151,7 @@ OBSERVATION:
 16|    return count
 [End of artifact]
 
-AGENT: {"thoughts": "I have generated the code to count the workers with helmets in the image, I must now run the code and print the output and write the visualization to the artifacts so I can see the result and the user can see the visaulization.", "response": "<execute_python>from code import count_workers_with_helmets\n    print(count_workers_with_helmets('/path/to/images/workers.png', 'workers_viz.png'))\n    write_media_artifact(artifacts, 'workers_viz.png')</execute_python>", "let_user_respond": false}
+AGENT: {"thoughts": "I have generated the code to count the workers with helmets in the image, I must now run the code and print the output and write the visualization to the artifacts so I can see the result and the user can see the visaulization.", "response": "<execute_python>from code import count_workers_with_helmets\n    print(count_workers_with_helmets('/path/to/images/workers.png', 'workers_viz.png'))\n    write_media_artifact(artifacts, 'workers_viz.png', 'workers_viz.png')</execute_python>", "let_user_respond": false}
 
 OBSERVATION:
 ----- stdout -----
@@ -163,7 +165,6 @@ AGENT: {"thoughts": "Because the user has supplied me with labels I can call obj
 
 OBSERVATION:
 [Fine tuning id: 23b3b022-5ebf-4798-9373-20ef36429abf]
-
 
 AGENT: {"thoughts": "The model has finished fine tuning, I will now replace the original florence2_phrase_grounding call with the fine tuning id.", "response": "I will not update the code to use the fine tuned model. <execute_python>use_object_detection_fine_tuning(artifacts, "code.py", "23b3b022-5ebf-4798-9373-20ef36429abf")</execute_python>", "let_user_respond": false}
 
@@ -182,8 +183,7 @@ OBSERVATION:
      count = 0
 [End of edits]
 
-
-AGENT: {"thoughts": "I have updated the code to use the fine tuned model, I must now run the code and print the output and write the visualization to the artifacts so I can see the result and the user can see the visaulization.", "response": "<execute_python>from code import count_workers_with_helmets\n    print(count_workers_with_helmets('/path/to/images/workers.png', 'workers_viz.png'))\n    write_media_artifact(artifacts, 'workers_viz.png')</execute_python>", "let_user_respond": false}
+AGENT: {"thoughts": "I have updated the code to use the fine tuned model, I must now run the code and print the output and write the visualization to the artifacts so I can see the result and the user can see the visaulization.", "response": "<execute_python>from code import count_workers_with_helmets\n    print(count_workers_with_helmets('/path/to/images/workers.png', 'workers_viz.png'))\n    write_media_artifact(artifacts, 'workers_viz.png', 'workers_viz.png')</execute_python>", "let_user_respond": false}
 
 OBSERVATION:
 ----- stdout -----

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -491,7 +491,7 @@ def check_and_load_image(code: str) -> List[str]:
     if not code.strip():
         return []
 
-    pattern = r"show_media_artifact\(\s*([^\)]+),\s*['\"]([^\)]+)['\"]\s*\)"
+    pattern = r"view_media_artifact\(\s*([^\)]+),\s*['\"]([^\)]+)['\"]\s*\)"
     match = re.search(pattern, code)
     if match:
         name = match.group(2)


### PR DESCRIPTION
Fixes several issues/bugs with VisionAgent:
- Fixes bug where if you pass a list of size > 2 to `edit_vision_code` it will crash because you've passed more than one user role message in a row
- Fixes bug where it would hallucinate when using `view_media_artifact`
- Fixes issue where it would try to call `view_media_artifact` on the users behalf
- Fixes issue where it could not write numpy arrays with `write_media_artifact`
- Adds rule for ensuring it will only call `edit_vision_code` on code generated from `generate_vision_code`, as opposed to using `edit_code_artifact`
- Adds rule for ensuring it will not continue to modify code for things the user did not ask for. For example, sometimes after generating vision code it would modify it to include visualizations
- Added more test cases for functions that modify code input and fixed some edge cases