### PR TITLE
fix: claude artifact path

### DIFF
--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -307,7 +307,7 @@ class VisionAgent(Agent):
             remote_artifacts_path = code_interpreter.upload_file(
                 self.local_artifacts_path
             )
-            artifacts_loaded = artifacts.show()
+            artifacts_loaded = artifacts.show(code_interpreter.remote_path)
             int_chat.append({"role": "observation", "content": artifacts_loaded})
             orig_chat.append({"role": "observation", "content": artifacts_loaded})
             self.streaming_message({"role": "observation", "content": artifacts_loaded})

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -107,13 +107,16 @@ class Artifacts:
                 with open(self.remote_save_path.parent / k, mode) as f:
                     f.write(v)
 
-    def show(self) -> str:
+    def show(self, uploaded_file_path: Optional[Union[str, Path]] = None) -> str:
         """Shows the artifacts that have been loaded and their remote save paths."""
+        loaded_path = (
+            Path(uploaded_file_path)
+            if uploaded_file_path is not None
+            else self.remote_save_path
+        )
         output_str = "[Artifacts loaded]\n"
         for k in self.artifacts.keys():
-            output_str += (
-                f"Artifact {k} loaded to {str(self.remote_save_path.parent / k)}\n"
-            )
+            output_str += f"Artifact {k} loaded to {str(loaded_path / k)}\n"
         output_str += "[End of artifacts]\n"
         print(output_str)
         return output_str

--- a/vision_agent/utils/execute.py
+++ b/vision_agent/utils/execute.py
@@ -464,7 +464,9 @@ print(f"Vision Agent version: {va_version}")"""
         _LOGGER.info(
             f"E2BCodeInterpreter (sandbox id: {self.interpreter.sandbox_id}) initialized:\n{sys_versions}"
         )
-        self.remote_path = Path(remote_path if remote_path is not None else WORKSPACE)
+        self.remote_path = Path(
+            remote_path if remote_path is not None else "/home/user"
+        )
 
     def close(self, *args: Any, **kwargs: Any) -> None:
         try:
@@ -713,7 +715,7 @@ def _get_e2b_env() -> Union[Dict[str, str], None]:
     openai_api_key = os.getenv("OPENAI_API_KEY", "")
     anthropic_api_key = os.getenv("ANTHROPIC_API_KEY", "")
     if openai_api_key or anthropic_api_key:
-        envs = {}
+        envs = {"WORKSPACE": os.getenv("WORKSPACE", "/home/user")}
         if openai_api_key:
             envs["OPENAI_API_KEY"] = openai_api_key
         if anthropic_api_key:


### PR DESCRIPTION
currently the conversation cannot be run with e2b interpreter:
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/95b769f3-38df-4d73-a75f-2f9c6c16d90b">

The root cause of this "FileNotFound" error is that the local_artifact_path (VAS side) and the remote code interpreter path (e2b side) are different.

The `generate_vision_code` will be executed in e2b, so the "artifacts.show()" should reflect the e2b path, not the local path in VAS side.

After this change, the conversation could be run in both local and e2b code interpreter.

