### PR TITLE
fix: labels should start at 1 instead of 0

### DIFF
--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -1603,7 +1603,7 @@ def extract_frames_and_timestamps(
     """
 
     def reformat(
-        frames_and_timestamps: List[Tuple[np.ndarray, float]]
+        frames_and_timestamps: List[Tuple[np.ndarray, float]],
     ) -> List[Dict[str, Union[np.ndarray, float]]]:
         return [
             {"frame": frame, "timestamp": timestamp}
@@ -2017,7 +2017,7 @@ def overlay_counting_results(
         fontsize,
     )
 
-    for i, elt in enumerate(instances):
+    for i, elt in enumerate(instances, 1):
         label = f"{i}"
         box = elt["bbox"]
 


### PR DESCRIPTION
when overlaying counting results visualizations, the label should not start at zero but at 1. 