### PR TITLE
fix: `view_media_artifact` error

### DIFF
--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -383,7 +383,7 @@ class VisionAgent(Agent):
                     obs_chat_elt: Message = {"role": "observation", "content": obs}
                     if media_obs and result.success:
                         obs_chat_elt["media"] = [
-                            Path(code_interpreter.remote_path) / media_ob
+                            Path(self.local_artifacts_path).parent / media_ob
                             for media_ob in media_obs
                         ]
 
@@ -407,6 +407,8 @@ class VisionAgent(Agent):
             code_interpreter.download_file(
                 str(remote_artifacts_path.name), str(self.local_artifacts_path)
             )
+            artifacts.load(self.local_artifacts_path)
+            artifacts.save()
         return orig_chat, artifacts
 
     def streaming_message(self, message: Dict[str, Any]) -> None:


### PR DESCRIPTION
https://landing938428.monday.com/boards/1922513007/pulses/1922526546

1. The `view_media_artifact` needs to load the media from observation first and then feed it to the LLM, so we need an local accessible media path (instead of the remote e2b path).
2. It's safer to load the artifact's files into local directory.

Tests:
1. View the result artifact:
- Prod error
![image](https://github.com/user-attachments/assets/fd1e1e50-e4c7-4abc-96f7-81cf71ba9bc8)

- Local run with e2b backend
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/bfbf5487-47f4-473c-a347-1214f6fb385f">


2. View the artifact first and then generate code
- Prod error
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/9f995bbf-47a1-4707-9d4b-e216e1eaa430">

- Local run with e2b backend
<img width="1968" alt="image" src="https://github.com/user-attachments/assets/18ea8003-ea9c-4a59-9690-971b1a094988">
