### PR TITLE
chore: update fl2sm2 chunk_length default param

### DIFF
--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -473,7 +473,7 @@ def florence2_sam2_image(
 
 
 def florence2_sam2_video_tracking(
-    prompt: str, frames: List[np.ndarray], chunk_length: Optional[int] = None
+    prompt: str, frames: List[np.ndarray], chunk_length: Optional[int] = 3
 ) -> List[List[Dict[str, Any]]]:
     """'florence2_sam2_video_tracking' is a tool that can segment and track multiple
     entities in a video given a text prompt such as category names or referring


### PR DESCRIPTION
Description
---
* Update the Florence2Sam2 video `chunk_length` default value from `None` to `3`
* The original model uses as default a value of `20` for `chunk_length` which in some cases can be a very large default value for the subsampled videos.