### PR TITLE
Fix Extract Files

### DIFF
--- a/tests/integ/test_tools.py
+++ b/tests/integ/test_tools.py
@@ -133,7 +133,7 @@ def test_florence2_phrase_grounding_fine_tune_id():
         fine_tune_id=FINE_TUNE_ID,
     )
     # this calls a fine-tuned florence2 model which is going to be worse at this task
-    assert 14 <= len(result) <= 26
+    assert 13 <= len(result) <= 26
     assert [res["label"] for res in result] == ["coin"] * len(result)
     assert all([all([0 <= x <= 1 for x in obj["bbox"]]) for obj in result])
 

--- a/tests/unit/test_vac.py
+++ b/tests/unit/test_vac.py
@@ -141,3 +141,16 @@ def check_helmets(image_path):
 # The function can be called with the image path"""
     code_out = strip_function_calls(code, exclusions=["register_heif_opener"])
     assert code_out == expected_code
+
+
+def test_strip_function_call_if_name_equal_main():
+    code = """import os
+def f():
+    print("Hello!")
+if __name__ == "__main__":
+    f()"""
+    expected_code = """import os
+def f():
+    print("Hello!")"""
+    code_out = strip_function_calls(code)
+    assert code_out == expected_code

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -149,11 +149,11 @@ def execute_code_action(
     result = code_interpreter.exec_isolation(
         BoilerplateCode.add_boilerplate(code, remote_path=artifact_remote_path)
     )
-    extract_and_save_files_to_artifacts(artifacts, code)
 
     obs = str(result.logs)
     if result.error:
         obs += f"\n{result.error}"
+    extract_and_save_files_to_artifacts(artifacts, code, obs)
     return result, obs
 
 
@@ -182,6 +182,7 @@ def execute_user_code_action(
         )
         if user_result.error:
             user_obs += f"\n{user_result.error}"
+        extract_and_save_files_to_artifacts(artifacts, user_code_action, user_obs)
     return user_result, user_obs
 
 

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -451,11 +451,6 @@ def generate_vision_code(
         custom_tool_names=custom_tool_names,
     )
 
-    # capture and save any files that were saved in the code to the artifacts
-    extract_and_save_files_to_artifacts(
-        artifacts, response["code"] + "\n" + response["test"]
-    )
-
     redisplay_results(response["test_result"])
     code = response["code"]
     artifacts[name] = code
@@ -535,10 +530,6 @@ def edit_vision_code(
         fixed_chat_history,
         test_multi_plan=False,
         custom_tool_names=custom_tool_names,
-    )
-    # capture and save any files that were saved in the code to the artifacts
-    extract_and_save_files_to_artifacts(
-        artifacts, response["code"] + "\n" + response["test"]
     )
 
     redisplay_results(response["test_result"])
@@ -766,7 +757,9 @@ def use_object_detection_fine_tuning(
     return diff
 
 
-def extract_and_save_files_to_artifacts(artifacts: Artifacts, code: str) -> None:
+def extract_and_save_files_to_artifacts(
+    artifacts: Artifacts, code: str, obs: str
+) -> None:
     """Extracts and saves files used in the code to the artifacts object.
 
     Parameters:
@@ -776,10 +769,14 @@ def extract_and_save_files_to_artifacts(artifacts: Artifacts, code: str) -> None
     try:
         response = extract_json(
             AnthropicLMM()(  # type: ignore
-                f"""You are a helpful AI assistant. Your job is to look at a snippet of code and return the file paths that are being saved in the file. Below is the code snippet:
+                f"""You are a helpful AI assistant. Your job is to look at a snippet of code and the output of running that code and return the file paths that are being saved in the file. Below is the code snippet:
 
 ```python
 {code}
+```
+
+```output
+{obs}
 ```
 
 Return the file paths in the following JSON format:


### PR DESCRIPTION
Moves the function to extract save files to after code has been executed by VisionAgent. Previously it was only looking at generated code, but now it looks at code and output in case something saves to a temporary file and you don't know the output until it's printed.