### PR TITLE
Fix Issues for App

### DIFF
--- a/examples/chat/app.py
+++ b/examples/chat/app.py
@@ -27,13 +27,19 @@ SAVE = {
     "style": {"bottom": "calc(50% - 4.25rem", "right": "0.4rem"},
 }
 # set artifacts remote_path to WORKSPACE
-artifacts = va.tools.meta_tools.Artifacts(WORKSPACE / "artifacts.pkl")
+local_artifacts_path = "artifacts.pkl"
+remote_artifacts_path = WORKSPACE / "artifacts.pkl"
+artifacts = va.tools.meta_tools.Artifacts(remote_artifacts_path, local_artifacts_path)
 if Path("artifacts.pkl").exists():
     artifacts.load("artifacts.pkl")
 else:
     artifacts.save("artifacts.pkl")
 
-agent = va.agent.VisionAgent(verbosity=1, local_artifacts_path="artifacts.pkl")
+agent = va.agent.VisionAgent(
+    verbosity=2,
+    local_artifacts_path=local_artifacts_path,
+    remote_artifacts_path=remote_artifacts_path,
+)
 
 st.set_page_config(layout="wide")
 
@@ -54,7 +60,9 @@ def update_messages(messages, lock):
     with lock:
         if Path("artifacts.pkl").exists():
             artifacts.load("artifacts.pkl")
-        new_chat, _ = agent.chat_with_artifacts(messages, artifacts=artifacts)
+        new_chat, _ = agent.chat_with_artifacts(
+            messages, artifacts=artifacts, test_multi_plan=False
+        )
         for new_message in new_chat[len(messages) :]:
             messages.append(new_message)
 

--- a/tests/integ/test_tools.py
+++ b/tests/integ/test_tools.py
@@ -86,7 +86,7 @@ def test_owl_v2_fine_tune_id():
         fine_tune_id=FINE_TUNE_ID,
     )
     # this calls a fine-tuned florence2 model which is going to be worse at this task
-    assert 14 <= len(result) <= 26
+    assert 13 <= len(result) <= 26
     assert [res["label"] for res in result] == ["coin"] * len(result)
     assert all([all([0 <= x <= 1 for x in obj["bbox"]]) for obj in result])
 

--- a/tests/integ/test_tools.py
+++ b/tests/integ/test_tools.py
@@ -205,7 +205,7 @@ def test_florence2_sam2_image_fine_tune_id():
         fine_tune_id=FINE_TUNE_ID,
     )
     # this calls a fine-tuned florence2 model which is going to be worse at this task
-    assert 14 <= len(result) <= 26
+    assert 13 <= len(result) <= 26
     assert [res["label"] for res in result] == ["coin"] * len(result)
     assert len([res["mask"] for res in result]) == len(result)
 

--- a/tests/unit/test_meta_tools.py
+++ b/tests/unit/test_meta_tools.py
@@ -22,7 +22,7 @@ def test_check_and_load_image_two():
 
 
 def test_use_object_detection_fine_tuning_none():
-    artifacts = Artifacts("test")
+    artifacts = Artifacts("test", "test")
     code = "print('Hello, World!')"
     artifacts["code"] = code
     output = use_object_detection_fine_tuning(artifacts, "code", "123")
@@ -33,7 +33,7 @@ def test_use_object_detection_fine_tuning_none():
 
 
 def test_use_object_detection_fine_tuning():
-    artifacts = Artifacts("test")
+    artifacts = Artifacts("test", "test")
     code = """florence2_phrase_grounding('one', image1)
 owl_v2_image('two', image2)
 florence2_sam2_image('three', image3)"""
@@ -50,7 +50,7 @@ florence2_sam2_image("three", image3, "123")"""
 
 
 def test_use_object_detection_fine_tuning_twice():
-    artifacts = Artifacts("test")
+    artifacts = Artifacts("test", "test")
     code = """florence2_phrase_grounding('one', image1)
 owl_v2_image('two', image2)
 florence2_sam2_image('three', image3)"""
@@ -75,7 +75,7 @@ florence2_sam2_image("three", image3, "456")"""
 
 
 def test_use_object_detection_fine_tuning_real_case():
-    artifacts = Artifacts("test")
+    artifacts = Artifacts("test", "test")
     code = "florence2_phrase_grounding('(strange arg)', image1)"
     expected_code = 'florence2_phrase_grounding("(strange arg)", image1, "123")'
     artifacts["code"] = code

--- a/vision_agent/agent/agent_utils.py
+++ b/vision_agent/agent/agent_utils.py
@@ -72,7 +72,9 @@ def extract_json(json_str: str) -> Dict[str, Any]:
         if json_dict is None:
             error_msg = f"Could not extract JSON from the given str: {json_orig}"
             _LOGGER.exception(error_msg)
-            raise ValueError(error_msg)
+            raise json.JSONDecodeError(
+                msg="Could not extract JSON", doc=json_orig, pos=0
+            )
 
         return json_dict
 

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -335,6 +335,8 @@ class VisionAgent(Agent):
             verbosity (int): The verbosity level of the agent.
             local_artifacts_path (Optional[Union[str, Path]]): The path to the local
                 artifacts file.
+            remote_artifacts_path (Optional[Union[str, Path]]): The path to the remote
+                artifacts file.
             callback_message (Optional[Callable[[Dict[str, Any]], None]]): Callback
                 function to send intermediate update messages.
             code_interpreter (Optional[Union[str, CodeInterpreter]]): For string values
@@ -643,6 +645,7 @@ class OpenAIVisionAgent(VisionAgent):
         agent: Optional[LMM] = None,
         verbosity: int = 0,
         local_artifacts_path: Optional[Union[str, Path]] = None,
+        remote_artifacts_path: Optional[Union[str, Path]] = None,
         callback_message: Optional[Callable[[Dict[str, Any]], None]] = None,
         code_interpreter: Optional[Union[str, CodeInterpreter]] = None,
     ) -> None:
@@ -653,6 +656,8 @@ class OpenAIVisionAgent(VisionAgent):
                 of other agents.
             verbosity (int): The verbosity level of the agent.
             local_artifacts_path (Optional[Union[str, Path]]): The path to the local
+                artifacts file.
+            remote_artifacts_path (Optional[Union[str, Path]]): The path to the remote
                 artifacts file.
             callback_message (Optional[Callable[[Dict[str, Any]], None]]): Callback
                 function to send intermediate update messages.
@@ -667,6 +672,7 @@ class OpenAIVisionAgent(VisionAgent):
             agent,
             verbosity,
             local_artifacts_path,
+            remote_artifacts_path,
             callback_message,
             code_interpreter,
         )
@@ -678,6 +684,7 @@ class AnthropicVisionAgent(VisionAgent):
         agent: Optional[LMM] = None,
         verbosity: int = 0,
         local_artifacts_path: Optional[Union[str, Path]] = None,
+        remote_artifacts_path: Optional[Union[str, Path]] = None,
         callback_message: Optional[Callable[[Dict[str, Any]], None]] = None,
         code_interpreter: Optional[Union[str, CodeInterpreter]] = None,
     ) -> None:
@@ -688,6 +695,8 @@ class AnthropicVisionAgent(VisionAgent):
                 of other agents.
             verbosity (int): The verbosity level of the agent.
             local_artifacts_path (Optional[Union[str, Path]]): The path to the local
+                artifacts file.
+            remote_artifacts_path (Optional[Union[str, Path]]): The path to the remote
                 artifacts file.
             callback_message (Optional[Callable[[Dict[str, Any]], None]]): Callback
                 function to send intermediate update messages.
@@ -702,6 +711,7 @@ class AnthropicVisionAgent(VisionAgent):
             agent,
             verbosity,
             local_artifacts_path,
+            remote_artifacts_path,
             callback_message,
             code_interpreter,
         )

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -153,7 +153,7 @@ def execute_code_action(
     obs = str(result.logs)
     if result.error:
         obs += f"\n{result.error}"
-    extract_and_save_files_to_artifacts(artifacts, code, obs)
+    extract_and_save_files_to_artifacts(artifacts, code, obs, result)
     return result, obs
 
 
@@ -562,10 +562,16 @@ class VisionAgent(Agent):
                             self.local_artifacts_path,
                             Path(self.local_artifacts_path).parent,
                         )
-                        obs_chat_elt["media"] = [
-                            Path(self.local_artifacts_path).parent / media_ob
-                            for media_ob in media_obs
-                        ]
+
+                        # check if the media is actually in the artifacts
+                        media_obs_chat = []
+                        for media_ob in media_obs:
+                            if media_ob not in artifacts.artifacts:
+                                media_obs_chat.append(
+                                    Path(self.local_artifacts_path).parent / media_ob
+                                )
+                        if media_obs_chat:
+                            obs_chat_elt["media"] = media_obs_chat
 
                     # don't add execution results to internal chat
                     int_chat.append(obs_chat_elt)

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -566,7 +566,7 @@ class VisionAgent(Agent):
                         # check if the media is actually in the artifacts
                         media_obs_chat = []
                         for media_ob in media_obs:
-                            if media_ob not in artifacts.artifacts:
+                            if media_ob in artifacts.artifacts:
                                 media_obs_chat.append(
                                     Path(self.local_artifacts_path).parent / media_ob
                                 )

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -155,6 +155,7 @@ def execute_code_action(
     obs = str(result.logs)
     if result.error:
         obs += f"\n{result.error}"
+    __import__("ipdb").set_trace()
     extract_and_save_files_to_artifacts(artifacts, code, obs, result)
     return result, obs
 
@@ -323,6 +324,7 @@ class VisionAgent(Agent):
         agent: Optional[LMM] = None,
         verbosity: int = 0,
         local_artifacts_path: Optional[Union[str, Path]] = None,
+        remote_artifacts_path: Optional[Union[str, Path]] = None,
         callback_message: Optional[Callable[[Dict[str, Any]], None]] = None,
         code_interpreter: Optional[Union[str, CodeInterpreter]] = None,
     ) -> None:
@@ -355,6 +357,14 @@ class VisionAgent(Agent):
                 Path(local_artifacts_path)
                 if local_artifacts_path is not None
                 else Path(tempfile.NamedTemporaryFile(delete=False).name)
+            ),
+        )
+        self.remote_artifacts_path = cast(
+            str,
+            (
+                Path(remote_artifacts_path)
+                if remote_artifacts_path is not None
+                else Path(WORKSPACE / "artifacts.pkl")
             ),
         )
 
@@ -433,7 +443,7 @@ class VisionAgent(Agent):
 
         if not artifacts:
             # this is setting remote artifacts path
-            artifacts = Artifacts(WORKSPACE / "artifacts.pkl")
+            artifacts = Artifacts(self.remote_artifacts_path, self.local_artifacts_path)
 
         # NOTE: each chat should have a dedicated code interpreter instance to avoid concurrency issues
         code_interpreter = (

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -231,9 +231,18 @@ def old_format_to_new_format(old_format_str: str) -> str:
     except json.JSONDecodeError:
         return old_format_str
 
-    thinking = old_format["thoughts"] if old_format["thoughts"].strip() != "" else None
-    let_user_respond = old_format["let_user_respond"]
-    if "<execute_python>" in old_format["response"]:
+    if "thoughts" in old_format:
+        thinking = (
+            old_format["thoughts"] if old_format["thoughts"].strip() != "" else None
+        )
+    else:
+        thinking = None
+
+    let_user_respond = (
+        old_format["let_user_respond"] if "let_user_respond" in old_format else True
+    )
+
+    if "response" in old_format and "<execute_python>" in old_format["response"]:
         execute_python = extract_tag(old_format["response"], "execute_python")
         response = (
             old_format["response"]
@@ -244,7 +253,7 @@ def old_format_to_new_format(old_format_str: str) -> str:
         )
     else:
         execute_python = None
-        response = old_format["response"]
+        response = old_format["response"] if "response" in old_format else None
 
     return json.dumps(
         {

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -155,7 +155,6 @@ def execute_code_action(
     obs = str(result.logs)
     if result.error:
         obs += f"\n{result.error}"
-    __import__("ipdb").set_trace()
     extract_and_save_files_to_artifacts(artifacts, code, obs, result)
     return result, obs
 

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -39,7 +39,7 @@ class BoilerplateCode:
     pre_code = [
         "from typing import *",
         "from vision_agent.utils.execute import CodeInterpreter",
-        "from vision_agent.tools.meta_tools import Artifacts, open_code_artifact, create_code_artifact, edit_code_artifact, get_tool_descriptions, generate_vision_code, edit_vision_code, view_media_artifact, object_detection_fine_tuning, use_object_detection_fine_tuning",
+        "from vision_agent.tools.meta_tools import Artifacts, open_code_artifact, create_code_artifact, edit_code_artifact, get_tool_descriptions, generate_vision_code, edit_vision_code, view_media_artifact, object_detection_fine_tuning, use_object_detection_fine_tuning, list_artifacts",
         "artifacts = Artifacts('{remote_path}', '{remote_path}')",
         "artifacts.load('{remote_path}')",
     ]

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -570,7 +570,7 @@ class VisionAgent(Agent):
                                 media_obs_chat.append(
                                     Path(self.local_artifacts_path).parent / media_ob
                                 )
-                        if media_obs_chat:
+                        if len(media_obs_chat) > 0:
                             obs_chat_elt["media"] = media_obs_chat
 
                     # don't add execution results to internal chat

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -98,8 +98,9 @@ def _clean_response(response: str) -> str:
 def run_conversation(orch: LMM, chat: List[Message]) -> Dict[str, Any]:
     chat = copy.deepcopy(chat)
 
+    # only add 10 most recent messages in the chat to not go over token limit
     conversation = ""
-    for chat_i in chat:
+    for chat_i in chat[-10:]:
         if chat_i["role"] == "user":
             conversation += f"USER: {chat_i['content']}\n\n"
         elif chat_i["role"] == "observation":

--- a/vision_agent/agent/vision_agent_prompts.py
+++ b/vision_agent/agent/vision_agent_prompts.py
@@ -1,7 +1,7 @@
 VA_CODE = """
 **Role**: You are a helpful agent that assists users with writing code.
 
-**Taks**: As a conversational agent, you are required to understand the user's request and provide a helpful response. Use a Chain-of-Thought approach to break down the problem, create a plan, and then provide a response. Ensure that your response is clear, concise, and helpful. You can use an interactive Python (Jupyter Notebook) environment, executing code with <execution_python>. You are given access to an `artifacts` object which contains files shared between you and the user. `artifacts` will be automatically saved everytime you execute python code.
+**Taks**: As a conversational agent, you are required to understand the user's request and provide a helpful response. Use a Chain-of-Thought approach to break down the problem, create a plan, and then provide a response. Ensure that your response is clear, concise, and helpful. You can use an interactive Python (Jupyter Notebook) environment, executing code with <execute_python>. You are given access to an `artifacts` object which contains files shared between you and the user. `artifacts` will be automatically saved only AFTER you execute python code.
 
 <execute_python>
 print("Hello World!")
@@ -28,6 +28,7 @@ Here is the current conversation so far:
 1. **Understand and Clarify**: Make sure you understand the task, ask clarifying questions if the task is not clear.
 2. **Code Generation**: Only use code provided in the Documentation in your <execute_python> tags. Only use `edit_vision_code` to modify code written by `generate_vision_code`.
 3. **Execute**: Do only what the user asked you to do and no more. If you need to ask the user a question or show your results to the user, set <let_user_respond> to `true`.
+4. **Artifacts**: Files are only saved in `artifacts` after <execute_python>, do not try to access artifacts until you observe that they are loaded.
 4. **Response**: Keep your responses short and concise. Provide the user only with the information they need to continue the conversation.
 5. **Output**: You can only respond with <thinking>, <response>, <execute_python>, and <let_user_respond> tags.
 

--- a/vision_agent/agent/vision_agent_prompts.py
+++ b/vision_agent/agent/vision_agent_prompts.py
@@ -1,7 +1,7 @@
 VA_CODE = """
 **Role**: You are a helpful agent that assists users with writing code.
 
-**Taks**: As a conversational agent, you are required to understand the user's request and provide a helpful response. Use a Chain-of-Thought approach to break down the problem, create a plan, and then provide a response. Ensure that your response is clear, concise, and helpful. You can use an interactive Python (Jupyter Notebook) environment, executing code with <execute_python>. You are given access to an `artifacts` object which contains files shared between you and the user. `artifacts` will be automatically saved only AFTER you execute python code.
+**Taks**: As a conversational agent, you are required to understand the user's request and provide a helpful response. Use a Chain-of-Thought approach to break down the problem, create a plan, and then provide a response. Ensure that your response is clear, concise, and helpful. You can use an interactive Python (Jupyter Notebook) environment, executing code with <execute_python>. You are given access to an `artifacts` object which contains files shared between you and the user. `artifacts` will be automatically saved only AFTER you execute python code. The user can see all `artifacts`.
 
 <execute_python>
 print("Hello World!")
@@ -26,11 +26,11 @@ Here is the current conversation so far:
 
 **Instructions**:
 1. **Understand and Clarify**: Make sure you understand the task, ask clarifying questions if the task is not clear.
-2. **Code Generation**: Only use code provided in the Documentation in your <execute_python> tags. Only use `edit_vision_code` to modify code written by `generate_vision_code`.
+2. **Code Generation**: Only use code provided in the Documentation in your <execute_python> tags. Only use `edit_vision_code` to modify code written by `generate_vision_code`. DO NOT run `edit_vision_code` or `edit_code_artifact` more than 2 times in a row and instead ask the user for help.
 3. **Execute**: Do only what the user asked you to do and no more. If you need to ask the user a question or show your results to the user, set <let_user_respond> to `true`.
 4. **Artifacts**: Files are only saved in `artifacts` after <execute_python>, do not try to access artifacts until you observe that they are loaded.
-4. **Response**: Keep your responses short and concise. Provide the user only with the information they need to continue the conversation.
-5. **Output**: You can only respond with <thinking>, <response>, <execute_python>, and <let_user_respond> tags.
+5. **Response**: Keep your responses short and concise. Provide the user only with the information they need to continue the conversation.
+6. **Output**: You can only respond with <thinking>, <response>, <execute_python>, and <let_user_respond> tags.
 
 <thinking>Your thoughts here...</thinking>
 <response>Your response to the user here...</response>

--- a/vision_agent/agent/vision_agent_prompts.py
+++ b/vision_agent/agent/vision_agent_prompts.py
@@ -1,7 +1,7 @@
 VA_CODE = """
 **Role**: You are a helpful agent that assists users with writing code.
 
-**Taks**: As a conversational agent, you are required to understand the user's request and provide a helpful response. Use a Chain-of-Thought approach to break down the problem, create a plan, and then provide a response. Ensure that your response is clear, concise, and helpful. You can use an interactive Python (Jupyter Notebook) environment, executing code with <execute_python>. You are given access to an `artifacts` object which contains files shared between you and the user. `artifacts` will be automatically saved only AFTER you execute python code. The user can see all `artifacts`.
+**Taks**: As a conversational agent, you are required to understand the user's request and provide a helpful response. Use a Chain-of-Thought approach to break down the problem, create a plan, and then provide a response. Ensure that your response is clear, concise, and helpful. You can use an interactive Python (Jupyter Notebook) environment, executing code with <execute_python>. You are given access to an `artifacts` object which contains files shared between you and the user. `artifacts` will be saved only AFTER you execute python code with `save_imgae` or `save_video`. The user can see all `artifacts`.
 
 <execute_python>
 print("Hello World!")
@@ -143,7 +143,7 @@ AGENT: <thinking>The image shows a cat and a dog sitting on the couch, I will te
 
 
 EXAMPLES_CODE3 = """
-USER: Can you create a function to count workers with helmets, return the count and save a visaulization of the bounding boxes?
+USER: Can you create a function to count workers with helmets, return the count and a visaulization of the bounding boxes?
 
 OBSERVATION:
 [Artifacts loaded]
@@ -169,7 +169,7 @@ generate_vision_code(artifacts, 'code.py', 'Can you create a function to count w
 OBSERVATION:
 [Artifact code.py (17 lines total)]
 0|from vision_agent.tools import load_image, florence2_phrase_grounding, closest_box_distance, overlay_bounding_boxes, save_image
-1|def count_workers_with_helmets(image_path: str, output_path: str):
+1|def count_workers_with_helmets(image_path: str):
 2|    image = load_image(image_path)
 3|    detections = florence2_phrase_grounding("worker, helmet", image)
 4|    workers = [d for d in detections if d['label'] == 'worker']
@@ -183,15 +183,16 @@ OBSERVATION:
 11|                break
 11|        if person_has_helmet:
 13|            count += 1
-14|    overlay_bounding_boxes(image, detections)
-15|    save_image(output_path, image)
-16|    return count
+14|    viz = overlay_bounding_boxes(image, detections)
+16|    return count, viz
 [End of artifact]
 
-AGENT: <thinking>I have generated the code to count the workers with helmets in the image, I must now run the code and print the output.</thinking>
+AGENT: <thinking>I have generated the code to count the workers with helmets in the image, I must now run the code, print the counts and save the visualization.</thinking>
 <execute_python>
 from code import count_workers_with_helmets
-print(count_workers_with_helmets('/path/to/images/workers.png', 'workers_viz.png'))
+count, viz = count_workers_with_helmets('/path/to/images/workers.png')
+save_image(viz, 'workers_viz.png')
+print(count)
 </execute_python>
 <let_user_respond>false</let_user_respond>
 

--- a/vision_agent/agent/vision_agent_prompts.py
+++ b/vision_agent/agent/vision_agent_prompts.py
@@ -54,7 +54,7 @@ generate_vision_code(artifacts, 'dog_detector.py', 'Can you write code to detect
 <let_user_respond>false</let_user_respond>
 
 OBSERVATION:
-[Artifact dog_detector.py]
+[Artifact dog_detector.py (5 lines total)]
 0|from vision_agent.tools import load_image, owl_v2
 1|def detect_dogs(image_path: str):
 2|    image = load_image(image_path)
@@ -95,7 +95,7 @@ edit_vision_code(artifacts, 'dog_detector.py', ['Can you write code to detect do
 <let_user_respond>false</let_user_respond>
 
 OBSERVATION:
-[Artifact dog_detector.py]
+[Artifact dog_detector.py (5 lines total)]
 0|from vision_agent.tools import load_image, owl_v2
 1|def detect_dogs(image_path: str):
 2|    image = load_image(image_path)
@@ -167,7 +167,7 @@ generate_vision_code(artifacts, 'code.py', 'Can you create a function to count w
 <let_user_respond>false</let_user_respond>
 
 OBSERVATION:
-[Artifact code.py]
+[Artifact code.py (17 lines total)]
 0|from vision_agent.tools import load_image, florence2_phrase_grounding, closest_box_distance, overlay_bounding_boxes, save_image
 1|def count_workers_with_helmets(image_path: str, output_path: str):
 2|    image = load_image(image_path)
@@ -202,7 +202,9 @@ OBSERVATION:
 AGENT: <thinking>Two workers with helmets are detected, I will show this to the user and ask them if the result looks good.</thinking>
 <response>The code to detect workers with helmets is saved in code.py and the visualization under 'workers_viz.png'.</response>
 <let_user_respond>true</let_user_respond>
+"""
 
+EXAMPLES_CODE3_EXTRA1 = """
 USER: The detections are slightly off. Can you fine tune florence2 using these labels? "[{'image_path': 'image1.png': 'labels': ['worker', 'helmet'], 'bboxes': [[235, 118, 294, 241], [232, 118, 294, 128]]}, {'image_path': 'image2.png': 'labels': ['worker', 'helmet'], 'bboxes': [[235, 118, 294, 241], [232, 118, 294, 128]]}]"
 
 AGENT: <thinking>Because the user has supplied me with labels I can call object_detection_fine_tuning on their behalf to fine tune the model</thinking>
@@ -248,5 +250,62 @@ OBSERVATION:
 
 AGENT: <thinking>Three workers with helmets are detected, I will show this to the user and ask them if the result looks good.</thinking>
 <response>I have updated the code using the fine tuned florence2_phrase_grounding model to count the workers wearing helmets in code.py and saved the visualization under 'workers_viz.png'.</response>
+<let_user_respond>true</let_user_respond>
+"""
+
+EXAMPLES_CODE3_EXTRA2 = """
+USER: Can you write a streamlit app that allows me to upload an image and count the workers with helmets?
+
+AGENT: <thinking>I will use edit_code_artifact to generate a streamlit app that allows the user to upload an image and count the workers with helmets.</thinking>
+<execute_python>
+CODE = '''
+import streamlit as st
+from code imoprt count_workers_with_helmets
+import os
+
+def main():
+    st.title("Worker with Helmet Counter")
+    uploaded_file = st.file_uploader("Choose image...", type=["jpeg", "jpg", "png"])
+    if uploaded_file is not None:
+        with open("temp_image.jpg", "wb") as f:
+            f.write(uploaded_file.read())
+
+        count = count_workers_with_helmets("temp_image.jpg", "temp_image_viz.jpg")
+        st.image("temp_image_viz.jpg")
+        st.write(f"Number of workers with helmets: {count}")
+        os.remove("temp_image.jpg")
+        os.remove("temp_image_viz.jpg")
+
+if __name__ == "__main__":
+    main()
+'''
+edit_code_artifact(artifacts, 'streamlit_app.py', CODE, 0, 0)
+</execute_python>
+
+OBSERVATION:
+[Artifact streamlit_app.py (19 lines total)]
+0|import streamlit as st
+1|from code imoprt count_workers_with_helmets
+2|import os
+3|
+4|def main():
+5|    st.title("Worker with Helmet Counter")
+6|    uploaded_file = st.file_uploader("Choose image...", type=["jpeg", "jpg", "png"])
+7|    if uploaded_file is not None:
+8|        with open("temp_image.jpg", "wb") as f:
+9|            f.write(uploaded_file.read())
+10|
+11|        count = count_workers_with_helmets("temp_image.jpg", "temp_image_viz.jpg")
+12|        st.image("temp_image_viz.jpg")
+13|        st.write(f"Number of workers with helmets: {count}")
+14|        os.remove("temp_image.jpg")
+15|        os.remove("temp_image_viz.jpg")
+16|
+17|if __name__ == "__main__":
+18|    main()
+[End of artifact]
+
+AGENT: <thinking>I have generated the streamlit app that allows the user to upload an image and count the workers</thinking>
+<response>The streamlit app is saved in streamlit_app.py, you can run the app by running `streamlit run streamlit_app.py`.</response>
 <let_user_respond>true</let_user_respond>
 """

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -833,21 +833,21 @@ def extract_and_save_files_to_artifacts(
     # file system.
     files = {}
     for res in result.results:
-        if len(res.formats()) == 1 and res.formats()[0] in ["png", "jpeg", "mp4"]:  # type: ignore
-            format = res.formats()[0]  # type: ignore
-            if format == "png":
-                data = base64.b64decode(res.png) if res.png is not None else None
-            elif format == "jpeg":
-                data = base64.b64decode(res.jpeg) if res.jpeg is not None else None
-            elif format == "mp4":
-                data = base64.b64decode(res.mp4) if res.mp4 is not None else None
-            else:
-                data = None
+        for format in res.formats():
+            if format in ["png", "jpeg", "mp4"]:  # type: ignore
+                if format == "png":
+                    data = base64.b64decode(res.png) if res.png is not None else None
+                elif format == "jpeg":
+                    data = base64.b64decode(res.jpeg) if res.jpeg is not None else None
+                elif format == "mp4":
+                    data = base64.b64decode(res.mp4) if res.mp4 is not None else None
+                else:
+                    data = None
 
-            if format not in files:
-                files[format] = [data]
-            else:
-                files[format].append(data)
+                if format not in files:
+                    files[format] = [data]
+                else:
+                    files[format].append(data)
 
     response = _extract_file_names(
         code,

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -806,7 +806,10 @@ The name cannot conflict with any of these existing names:
 {str(existing_names)}
 
 Return the file paths in the following JSON format:
-{{"png": ["image_name1.png", "other_image_name.png"], "mp4": ["video_name.mp4"]}}"""
+```json
+{{"png": ["image_name1.png", "other_image_name.png"], "mp4": ["video_name.mp4"]}}
+```
+"""
             )
         )
     except json.JSONDecodeError:

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -835,7 +835,7 @@ def extract_and_save_files_to_artifacts(
     files = {}
     for res in result.results:
         for format in res.formats():
-            if format in ["png", "jpeg", "mp4"]:  # type: ignore
+            if format in ["png", "jpeg", "mp4"]:
                 if format == "png":
                     data = base64.b64decode(res.png) if res.png is not None else None
                 elif format == "jpeg":

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -881,7 +881,6 @@ META_TOOL_DOCSTRING = get_tool_documentation(
         open_code_artifact,
         create_code_artifact,
         edit_code_artifact,
-        generate_vision_plan,
         generate_vision_code,
         edit_vision_code,
         view_media_artifact,

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -28,7 +28,6 @@ CURRENT_FILE = None
 CURRENT_LINE = 0
 DEFAULT_WINDOW_SIZE = 100
 ZMQ_PORT = os.environ.get("ZMQ_PORT", None)
-VERBOSITY = os.environ.get("VERBOSITY", 0)
 
 
 def report_progress_callback(port: int, inp: Dict[str, Any]) -> None:
@@ -443,14 +442,16 @@ def generate_vision_code(
             dogs = owl_v2("dog", image)
             return dogs
     """
+    # verbosity is set to 0 to avoid adding extra content to the VisionAgent conversation
     if ZMQ_PORT is not None:
         agent = va.agent.VisionAgentCoder(
             report_progress_callback=lambda inp: report_progress_callback(
                 int(ZMQ_PORT), inp
-            )
+            ),
+            verbosity=0,
         )
     else:
-        agent = va.agent.VisionAgentCoder(verbosity=int(VERBOSITY))
+        agent = va.agent.VisionAgentCoder(verbosity=0)
 
     fixed_chat: List[Message] = [{"role": "user", "content": chat, "media": media}]
     response = agent.generate_code(
@@ -514,7 +515,8 @@ def edit_vision_code(
             return dogs
     """
 
-    agent = va.agent.VisionAgentCoder(verbosity=int(VERBOSITY))
+    # verbosity is set to 0 to avoid adding extra content to the VisionAgent conversation
+    agent = va.agent.VisionAgentCoder(verbosity=0)
     if name not in artifacts:
         print(f"[Artifact {name} does not exist]")
         return f"[Artifact {name} does not exist]"

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -269,14 +269,14 @@ def edit_code_artifact(
         artifacts[name] = ""
 
     total_lines = len(artifacts[name].splitlines())
-    if start < -1 or end < -1 or start > end or end > total_lines:
-        print("[Invalid line range]")
-        return "[Invalid line range]"
-
     if start == -1:
         start = total_lines
     if end == -1:
         end = total_lines
+
+    if start < 0 or end < 0 or start > end or end > total_lines:
+        print("[Invalid line range]")
+        return "[Invalid line range]"
 
     new_content_lines = content.splitlines(keepends=True)
     new_content_lines = [
@@ -378,14 +378,16 @@ def generate_vision_plan(
         [End Plan Context]
     """
 
+    # verbosity is set to 0 to avoid adding extra content to the VisionAgent conversation
     if ZMQ_PORT is not None:
         agent = va.agent.VisionAgentPlanner(
             report_progress_callback=lambda inp: report_progress_callback(
                 int(ZMQ_PORT), inp
-            )
+            ),
+            verbosity=0,
         )
     else:
-        agent = va.agent.VisionAgentPlanner()
+        agent = va.agent.VisionAgentPlanner(verbosity=0)
 
     fixed_chat: List[Message] = [{"role": "user", "content": chat, "media": media}]
     response = agent.generate_plan(
@@ -778,7 +780,7 @@ def _find_name(file: Path, names: List[str]) -> str:
         new_name = f"{name}_output_{i}{suffix}"
         if new_name not in names:
             return new_name
-    return f"{name}_output_{str(uuid.uuid4())}{suffix}"
+    return f"{name}_output_{str(uuid.uuid4())[:4]}{suffix}"
 
 
 def _extract_file_names(

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -662,10 +662,10 @@ def get_diff_with_prompts(name: str, before: str, after: str) -> str:
 
 
 def use_extra_vision_agent_args(
-    code: str,
+    code: Optional[str],
     test_multi_plan: bool = True,
     custom_tool_names: Optional[List[str]] = None,
-) -> str:
+) -> Optional[str]:
     """This is for forcing arguments passed by the user to VisionAgent into the
     VisionAgentCoder call.
 
@@ -677,6 +677,8 @@ def use_extra_vision_agent_args(
     Returns:
         str: The edited code.
     """
+    if code is None:
+        return None
     red = RedBaron(code)
     for node in red:
         # seems to always be atomtrailers not call type

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -87,8 +87,11 @@ class Artifacts:
     need to be in sync with the remote environment the VisionAgent is running in.
     """
 
-    def __init__(self, remote_save_path: Union[str, Path]) -> None:
+    def __init__(
+        self, remote_save_path: Union[str, Path], local_save_path: Union[str, Path]
+    ) -> None:
         self.remote_save_path = Path(remote_save_path)
+        self.local_save_path = Path(local_save_path)
         self.artifacts: Dict[str, Any] = {}
 
         self.code_sandbox_runtime = None
@@ -132,9 +135,7 @@ class Artifacts:
         return output_str
 
     def save(self, local_path: Optional[Union[str, Path]] = None) -> None:
-        save_path = (
-            Path(local_path) if local_path is not None else self.remote_save_path
-        )
+        save_path = Path(local_path) if local_path is not None else self.local_save_path
         with open(save_path, "wb") as f:
             pkl.dump(self.artifacts, f)
 
@@ -876,6 +877,7 @@ def extract_and_save_files_to_artifacts(
                         list(artifacts.artifacts.keys()),
                     )
                     artifacts[new_name] = files[format][j]
+    artifacts.save()
 
 
 META_TOOL_DOCSTRING = get_tool_documentation(


### PR DESCRIPTION
Fixes some bugs:
- Fixes a bug on switching between new and old format
- Fixes bug where json extract was raising ValueError and not getting caught properly
- Fixes bug where file names were getting added to the artifact but they didn't exist
- Changes media extraction to use media from ipython display call
- Fixes bug with edit_code_artifact where VA was using -1 as line number. Also adds an example of how to use edit_code_artifact in VA prompt
- Removes verbosity env arg which was taking up extra token space in the VA chat observations and limits "viewable" conversation to 10 messages to keep tokens lower
- Updates prompts on how to deal with artifacts, "user can see artifacts", "artifacts are saved only after execution is finished", etc.