### PR TITLE
fix: streaming back assistant response before parse code action

### DIFF
--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -492,19 +492,10 @@ class VisionAgent(Agent):
                     }
                 )
 
+                code_action = response.get("execute_python", None)
                 # sometimes it gets stuck in a loop, so we force it to exit
                 if last_response == response:
                     response["let_user_respond"] = True
-
-                finished = response.get("let_user_respond", False)
-
-                code_action = response.get("execute_python", None)
-                if code_action is not None:
-                    code_action = use_extra_vision_agent_args(
-                        code_action, test_multi_plan, custom_tool_names
-                    )
-
-                if last_response == response:
                     self.streaming_message(
                         {
                             "role": "assistant",
@@ -514,7 +505,7 @@ class VisionAgent(Agent):
                                 "value": "Agent is stuck in conversation loop, exited",
                                 "traceback_raw": [],
                             },
-                            "finished": finished and code_action is None,
+                            "finished": code_action is None,
                         }
                     )
                 else:
@@ -524,8 +515,16 @@ class VisionAgent(Agent):
                             "content": new_format_to_old_format(
                                 add_step_descriptions(response)
                             ),
-                            "finished": finished and code_action is None,
+                            "finished": response.get("let_user_respond", False)
+                            and code_action is None,
                         }
+                    )
+
+                finished = response.get("let_user_respond", False)
+
+                if code_action is not None:
+                    code_action = use_extra_vision_agent_args(
+                        code_action, test_multi_plan, custom_tool_names
                     )
 
                 if code_action is not None:


### PR DESCRIPTION
The generated code could be failed to parse and the error message were streaming back to UI, however, if that happened, the latest assistant response were not streamed because the while loop was break, so moved the code to stream back assistant response first before parse code action.

Confirmed with running examples in UI and make sure the UI behaves the same.
<img width="1456" alt="image" src="https://github.com/user-attachments/assets/b99a17a4-e288-4126-afef-4996afdbdb57">
