### PR TITLE
chore: add qwen2vl-images vqa tool

### DIFF
--- a/tests/integ/test_tools.py
+++ b/tests/integ/test_tools.py
@@ -33,7 +33,7 @@ from vision_agent.tools import (
     template_match,
     vit_image_classification,
     vit_nsfw_classification,
-    docqa_images,
+    qwen2_vl_images_vqa,
     video_temporal_localization,
 )
 
@@ -353,9 +353,9 @@ def test_ixc25_image_vqa():
     assert "cat" in result.strip()
 
 
-def test_docqa_images():
+def test_qwen2_vl_images_vqa():
     img = ski.data.page()
-    result = docqa_images(
+    result = qwen2_vl_images_vqa(
         prompt="What is the document about?",
         images=[img],
     )

--- a/tests/integ/test_tools.py
+++ b/tests/integ/test_tools.py
@@ -33,7 +33,7 @@ from vision_agent.tools import (
     template_match,
     vit_image_classification,
     vit_nsfw_classification,
-    docqa_image,
+    docqa_images,
     video_temporal_localization,
 )
 
@@ -353,11 +353,11 @@ def test_ixc25_image_vqa():
     assert "cat" in result.strip()
 
 
-def test_docqa_image():
+def test_docqa_images():
     img = ski.data.page()
-    result = docqa_image(
+    result = docqa_images(
         prompt="What is the document about?",
-        image=img,
+        images=[img],
     )
     assert len(result) > 0
 

--- a/tests/integ/test_tools.py
+++ b/tests/integ/test_tools.py
@@ -33,6 +33,7 @@ from vision_agent.tools import (
     template_match,
     vit_image_classification,
     vit_nsfw_classification,
+    docqa_image,
 )
 
 FINE_TUNE_ID = "65ebba4a-88b7-419f-9046-0750e30250da"
@@ -349,6 +350,15 @@ def test_ixc25_image_vqa():
         image=img,
     )
     assert "cat" in result.strip()
+
+
+def test_docqa_image():
+    img = ski.data.page()
+    result = docqa_image(
+        prompt="What is the document about?",
+        image=img,
+    )
+    assert len(result) > 0
 
 
 def test_ixc25_video_vqa():

--- a/vision_agent/tools/__init__.py
+++ b/vision_agent/tools/__init__.py
@@ -65,7 +65,7 @@ from .tools import (
     template_match,
     vit_image_classification,
     vit_nsfw_classification,
-    docqa_images,
+    qwen2_vl_images_vqa,
     video_temporal_localization,
 )
 

--- a/vision_agent/tools/__init__.py
+++ b/vision_agent/tools/__init__.py
@@ -65,6 +65,7 @@ from .tools import (
     template_match,
     vit_image_classification,
     vit_nsfw_classification,
+    docqa_image,
 )
 
 __new_tools__ = [

--- a/vision_agent/tools/__init__.py
+++ b/vision_agent/tools/__init__.py
@@ -65,7 +65,7 @@ from .tools import (
     template_match,
     vit_image_classification,
     vit_nsfw_classification,
-    docqa_image,
+    docqa_images,
     video_temporal_localization,
 )
 

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -852,8 +852,8 @@ def ixc25_image_vqa(prompt: str, image: np.ndarray) -> str:
     return cast(str, data["answer"])
 
 
-def docqa_image(prompt: str, image: np.ndarray) -> str:
-    """'docqa_image' is a tool that can answer any questions about  images of documents.
+def docqa_images(prompt: str, images: List[np.ndarray]) -> str:
+    """'docqa_images' is a tool that can answer any questions about  images of documents.
     It returns text as an answer to the question.
 
     Parameters:
@@ -865,18 +865,18 @@ def docqa_image(prompt: str, image: np.ndarray) -> str:
 
     Example
     -------
-        >>> docqa_image('Give a summary if the document', image)
+        >>> docqa_images('Give a summary of the document', images)
         'The document talks about the history of the United States of America and its...'
     """
-    if image.shape[0] < 1 or image.shape[1] < 1:
-        raise ValueError(f"Image is empty, image shape: {image.shape}")
+    for image in images:
+        if image.shape[0] < 1 or image.shape[1] < 1:
+            raise ValueError(f"Image is empty, image shape: {image.shape}")
 
-    buffer_bytes = numpy_to_bytes(image)
-    files = [("images", buffer_bytes)]
+    files = [("images", numpy_to_bytes(image)) for image in images]
     payload = {
         "prompt": prompt,
         "model": "qwen2vl",
-        "function_name": "docqa_image",
+        "function_name": "docqa_images",
     }
     data: Dict[str, Any] = send_inference_request(
         payload, "image-to-text", files=files, v2=True

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -2194,7 +2194,6 @@ FUNCTION_TOOLS = [
     generate_pose_image,
     closest_mask_distance,
     closest_box_distance,
-    docqa_image,
 ]
 
 UTIL_TOOLS = [

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -852,20 +852,21 @@ def ixc25_image_vqa(prompt: str, image: np.ndarray) -> str:
     return cast(str, data["answer"])
 
 
-def docqa_images(prompt: str, images: List[np.ndarray]) -> str:
-    """'docqa_images' is a tool that can answer any questions about  images of documents.
-    It returns text as an answer to the question.
+def qwen2_vl_images_vqa(prompt: str, images: List[np.ndarray]) -> str:
+    """'qwen2_vl_images_vqa' is a tool that can answer any questions about arbitrary images
+    including regular images or images of documents or presentations. It returns text
+    as an answer to the question.
 
     Parameters:
         prompt (str): The question about the document image
-        image (np.ndarray): The reference image used for the question
+        images (List[np.ndarray]): The reference images used for the question
 
     Returns:
         str: A string which is the answer to the given prompt.
 
     Example
     -------
-        >>> docqa_images('Give a summary of the document', images)
+        >>> qwen2_vl_images_vqa('Give a summary of the document', images)
         'The document talks about the history of the United States of America and its...'
     """
     for image in images:
@@ -876,7 +877,7 @@ def docqa_images(prompt: str, images: List[np.ndarray]) -> str:
     payload = {
         "prompt": prompt,
         "model": "qwen2vl",
-        "function_name": "docqa_images",
+        "function_name": "qwen2_vl_images_vqa",
     }
     data: Dict[str, Any] = send_inference_request(
         payload, "image-to-text", files=files, v2=True

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -852,6 +852,38 @@ def ixc25_image_vqa(prompt: str, image: np.ndarray) -> str:
     return cast(str, data["answer"])
 
 
+def docqa_image(prompt: str, image: np.ndarray) -> str:
+    """'docqa_image' is a tool that can answer any questions about  images of documents.
+    It returns text as an answer to the question.
+
+    Parameters:
+        prompt (str): The question about the document image
+        image (np.ndarray): The reference image used for the question
+
+    Returns:
+        str: A string which is the answer to the given prompt.
+
+    Example
+    -------
+        >>> docqa_image('Give a summary if the document', image)
+        'The document talks about the history of the United States of America and its...'
+    """
+    if image.shape[0] < 1 or image.shape[1] < 1:
+        raise ValueError(f"Image is empty, image shape: {image.shape}")
+
+    buffer_bytes = numpy_to_bytes(image)
+    files = [("images", buffer_bytes)]
+    payload = {
+        "prompt": prompt,
+        "model": "qwen2vl",
+        "function_name": "docqa_image",
+    }
+    data: Dict[str, Any] = send_inference_request(
+        payload, "image-to-text", files=files, v2=True
+    )
+    return cast(str, data)
+
+
 def ixc25_video_vqa(prompt: str, frames: List[np.ndarray]) -> str:
     """'ixc25_video_vqa' is a tool that can answer any questions about arbitrary videos
     including regular videos or videos of documents or presentations. It returns text
@@ -2162,6 +2194,7 @@ FUNCTION_TOOLS = [
     generate_pose_image,
     closest_mask_distance,
     closest_box_distance,
+    docqa_image,
 ]
 
 UTIL_TOOLS = [


### PR DESCRIPTION
Description
---
* Add qwen2vl-images vqa tool for answering questions on image documents.
* The function accepts list of images to answer questions to. The response is a single string.

Tests
---
![Screenshot 2024-10-22 at 2 15 44 PM](https://github.com/user-attachments/assets/f67c7c3a-6ef4-4380-b594-d160d5559239)
