### PR TITLE
fix: add empty check for bboxes in overlay_bounding_boxes

### DIFF
--- a/tests/unit/tools/test_tools.py
+++ b/tests/unit/tools/test_tools.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import numpy as np
 
-from vision_agent.tools.tools import save_image, save_video
+from vision_agent.tools.tools import overlay_bounding_boxes, save_image, save_video
 
 
 def test_saves_frames_without_output_path():
@@ -67,3 +67,10 @@ def test_save_invalid_frame():
         save_video(frames, "tmp.mp4")
     except ValueError as e:
         assert str(e) == "A frame is not a valid NumPy array with shape (H, W, C)"
+
+
+def test_overlay_bounding_boxes_with_empty_bboxes():
+    image = np.zeros((480, 640, 3), dtype=np.uint8)
+    bboxes = []
+    output = overlay_bounding_boxes(image, bboxes)
+    assert np.array_equal(image, output)

--- a/tests/unit/tools/test_tools.py
+++ b/tests/unit/tools/test_tools.py
@@ -69,8 +69,17 @@ def test_save_invalid_frame():
         assert str(e) == "A frame is not a valid NumPy array with shape (H, W, C)"
 
 
-def test_overlay_bounding_boxes_with_empty_bboxes():
+def test_overlay_bounding_boxes_with_empty_bboxes_single_image():
     image = np.zeros((480, 640, 3), dtype=np.uint8)
     bboxes = []
     output = overlay_bounding_boxes(image, bboxes)
     assert np.array_equal(image, output)
+
+
+def test_overlay_bounding_boxes_with_empty_bboxes_multiple_images():
+    image1 = np.zeros((480, 640, 3), dtype=np.uint8)
+    image2 = np.zeros((400, 600, 3), dtype=np.uint8)
+    bboxes = []
+    output1, output2 = overlay_bounding_boxes([image1, image2], bboxes)
+    assert np.array_equal(image1, output1)
+    assert np.array_equal(image2, output2)

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -1970,7 +1970,10 @@ def overlay_bounding_boxes(
     medias_int: List[np.ndarray] = (
         [medias] if isinstance(medias, np.ndarray) else medias
     )
-    bbox_int = [bboxes] if len(bboxes) > 0 and isinstance(bboxes[0], dict) else bboxes
+    if len(bboxes) == 0:
+        bbox_int = [[]]
+    else:
+        bbox_int = [bboxes] if isinstance(bboxes[0], dict) else bboxes
     bbox_int = cast(List[List[Dict[str, Any]]], bbox_int)
     labels = set([bb["label"] for b in bbox_int for bb in b])
 

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -1971,10 +1971,13 @@ def overlay_bounding_boxes(
         [medias] if isinstance(medias, np.ndarray) else medias
     )
     if len(bboxes) == 0:
-        bbox_int = [[]]
+        bbox_int: List[List[Dict[str, Any]]] = [[] for _ in medias_int]
     else:
-        bbox_int = [bboxes] if isinstance(bboxes[0], dict) else bboxes
-    bbox_int = cast(List[List[Dict[str, Any]]], bbox_int)
+        if isinstance(bboxes[0], dict):
+            bbox_int = [cast(List[Dict[str, Any]], bboxes)]
+        else:
+            bbox_int = cast(List[List[Dict[str, Any]]], bboxes)
+
     labels = set([bb["label"] for b in bbox_int for bb in b])
 
     if len(labels) > len(COLORS):

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -1970,7 +1970,7 @@ def overlay_bounding_boxes(
     medias_int: List[np.ndarray] = (
         [medias] if isinstance(medias, np.ndarray) else medias
     )
-    bbox_int = [bboxes] if isinstance(bboxes[0], dict) else bboxes
+    bbox_int = [bboxes] if len(bboxes) > 0 and isinstance(bboxes[0], dict) else bboxes
     bbox_int = cast(List[List[Dict[str, Any]]], bbox_int)
     labels = set([bb["label"] for b in bbox_int for bb in b])
 


### PR DESCRIPTION
fix: add empty check for bboxes in overlay_bounding_boxes

Problem:

We usually generate codes to directly pass bboxes returned from inference. If the inference happened to detect nothing, an empty list will be passed into `overlay_bounding_boxes`, which will raise an IndexError.

```python
   # Overlay bounding boxes on the image
    image_with_boxes = overlay_bounding_boxes(image, car_detections)
    
    # Save the resulting image
    output_path = image_path.rsplit('.', 1)[0] + '_with_cars.jpg'
    save_image(image_with_boxes, output_path)
```

Solution:

Add empty array check inside `overlay_bounding_boxes`