### PR TITLE
feat: change the `Artifact` to be folder-based

### DIFF
--- a/tests/unit/test_meta_tools.py
+++ b/tests/unit/test_meta_tools.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from vision_agent.tools.meta_tools import (
     Artifacts,
     check_and_load_image,
@@ -22,7 +23,7 @@ def test_check_and_load_image_two():
 
 
 def test_use_object_detection_fine_tuning_none():
-    artifacts = Artifacts("test", "test")
+    artifacts = Artifacts(Path.cwd())
     code = "print('Hello, World!')"
     artifacts["code"] = code
     output = use_object_detection_fine_tuning(artifacts, "code", "123")
@@ -33,7 +34,7 @@ def test_use_object_detection_fine_tuning_none():
 
 
 def test_use_object_detection_fine_tuning():
-    artifacts = Artifacts("test", "test")
+    artifacts = Artifacts(Path.cwd())
     code = """florence2_phrase_grounding('one', image1)
 owl_v2_image('two', image2)
 florence2_sam2_image('three', image3)"""
@@ -50,7 +51,7 @@ florence2_sam2_image("three", image3, "123")"""
 
 
 def test_use_object_detection_fine_tuning_twice():
-    artifacts = Artifacts("test", "test")
+    artifacts = Artifacts(Path.cwd())
     code = """florence2_phrase_grounding('one', image1)
 owl_v2_image('two', image2)
 florence2_sam2_image('three', image3)"""
@@ -75,7 +76,7 @@ florence2_sam2_image("three", image3, "456")"""
 
 
 def test_use_object_detection_fine_tuning_real_case():
-    artifacts = Artifacts("test", "test")
+    artifacts = Artifacts(Path.cwd())
     code = "florence2_phrase_grounding('(strange arg)', image1)"
     expected_code = 'florence2_phrase_grounding("(strange arg)", image1, "123")'
     artifacts["code"] = code

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -431,11 +431,7 @@ class VisionAgent(Agent):
                 self.streaming_message(
                     {
                         "role": "observation",
-                        "content": (
-                            json.dumps(user_obs)
-                            if not isinstance(user_obs, str)
-                            else user_obs
-                        ),
+                        "content": user_obs,
                         "execution": user_result,
                         "finished": finished,
                     }
@@ -466,10 +462,8 @@ class VisionAgent(Agent):
                     self.streaming_message(
                         {
                             "role": "assistant",
-                            "content": json.dumps(
-                                new_format_to_old_format(
-                                    add_step_descriptions(response)
-                                )
+                            "content": new_format_to_old_format(
+                                add_step_descriptions(response)
                             ),
                             "finished": response.get("let_user_respond", False)
                             and code_action is None,
@@ -517,10 +511,8 @@ class VisionAgent(Agent):
                     self.streaming_message(
                         {
                             "role": "observation",
-                            "content": (
-                                json.dumps(obs) if not isinstance(obs, str) else obs
-                            ),
-                            "execution": result.to_json(),
+                            "content": obs,
+                            "execution": result,
                             "finished": finished,
                         }
                     )

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -509,7 +509,6 @@ class VisionAgent(Agent):
                     )
                     obs_chat_elt: Message = {"role": "observation", "content": obs}
                     media_obs = check_and_load_image(code_action)
-                    print(media_obs)
                     if media_obs and result.success:
                         obs_chat_elt["media"] = [
                             artifacts.cwd / media_ob for media_ob in media_obs

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -18,7 +18,6 @@ from vision_agent.lmm import LMM, AnthropicLMM, Message, OpenAILMM
 from vision_agent.tools.meta_tools import (
     META_TOOL_DOCSTRING,
     Artifacts,
-    check_and_load_image,
     use_extra_vision_agent_args,
 )
 from vision_agent.utils import CodeInterpreterFactory
@@ -36,14 +35,10 @@ class BoilerplateCode:
     pre_code = [
         "from typing import *",
         "from vision_agent.utils.execute import CodeInterpreter",
-        "from vision_agent.tools.meta_tools import Artifacts, open_code_artifact, create_code_artifact, edit_code_artifact, get_tool_descriptions, generate_vision_code, edit_vision_code, view_media_artifact, object_detection_fine_tuning, use_object_detection_fine_tuning, list_artifacts, capture_files_into_artifacts",
-        "artifacts = Artifacts('{remote_path}', '{remote_path}')",
-        "artifacts.load('{remote_path}')",
+        "from vision_agent.tools.meta_tools import Artifacts, open_code_artifact, create_code_artifact, edit_code_artifact, get_tool_descriptions, generate_vision_code, edit_vision_code, view_media_artifact, object_detection_fine_tuning, use_object_detection_fine_tuning, list_artifacts",
+        "artifacts = Artifacts('{cwd}')",
     ]
-    post_code = [
-        "capture_files_into_artifacts(artifacts)",
-        "artifacts.save()",
-    ]
+    post_code = []
 
     @staticmethod
     def add_boilerplate(code: str, **format: Any) -> str:
@@ -149,9 +144,7 @@ def execute_code_action(
     code_interpreter: CodeInterpreter,
 ) -> Tuple[Execution, str]:
     result = code_interpreter.exec_isolation(
-        BoilerplateCode.add_boilerplate(
-            code, remote_path=str(artifacts.remote_save_path)
-        )
+        BoilerplateCode.add_boilerplate(code, cwd=str(artifacts.cwd))
     )
 
     obs = str(result.logs)
@@ -210,19 +203,6 @@ def add_step_descriptions(response: Dict[str, Any]) -> Dict[str, Any]:
         response["response"] = description
 
     return response
-
-
-def setup_artifacts() -> Artifacts:
-    # this is setting remote artifacts path
-    sandbox = os.environ.get("CODE_SANDBOX_RUNTIME", None)
-    if sandbox is None or sandbox == "local":
-        remote = WORKSPACE / "artifacts.pkl"
-    elif sandbox == "e2b":
-        remote = Path("/home/user/artifacts.pkl")
-    else:
-        raise ValueError(f"Unknown code sandbox runtime {sandbox}")
-    artifacts = Artifacts(remote, Path(os.getcwd()) / "artifacts.pkl")
-    return artifacts
 
 
 def new_format_to_old_format(new_format: Dict[str, Any]) -> Dict[str, Any]:
@@ -297,9 +277,10 @@ class VisionAgent(Agent):
     def __init__(
         self,
         agent: Optional[LMM] = None,
+        cwd: Optional[Union[Path, str]] = None,
         verbosity: int = 0,
         callback_message: Optional[Callable[[Dict[str, Any]], None]] = None,
-        code_interpreter: Optional[Union[str, CodeInterpreter]] = None,
+        code_sandbox_runtime: Optional[str] = None,
     ) -> None:
         """Initialize the VisionAgent.
 
@@ -317,9 +298,10 @@ class VisionAgent(Agent):
 
         self.agent = AnthropicLMM(temperature=0.0) if agent is None else agent
         self.max_iterations = 12
+        self.cwd = Path(cwd) if cwd is not None else Path.cwd()
         self.verbosity = verbosity
-        self.code_interpreter = code_interpreter
         self.callback_message = callback_message
+        self.code_sandbox_runtime = code_sandbox_runtime
         if self.verbosity >= 1:
             _LOGGER.setLevel(logging.INFO)
 
@@ -397,40 +379,20 @@ class VisionAgent(Agent):
             raise ValueError("chat cannot be empty")
 
         if not artifacts:
-            artifacts = setup_artifacts()
+            artifacts = Artifacts(self.cwd)
 
-        # NOTE: each chat should have a dedicated code interpreter instance to avoid concurrency issues
-        code_interpreter = (
-            self.code_interpreter
-            if self.code_interpreter is not None
-            and not isinstance(self.code_interpreter, str)
-            else CodeInterpreterFactory.new_instance(
-                code_sandbox_runtime=self.code_interpreter,
-                remote_path=artifacts.remote_save_path.parent,
-            )
-        )
-
-        if code_interpreter.remote_path != artifacts.remote_save_path.parent:
-            raise ValueError(
-                f"Code interpreter remote path {code_interpreter.remote_path} does not match artifacts remote path {artifacts.remote_save_path.parent}"
-            )
-
-        with code_interpreter:
+        with CodeInterpreterFactory.new_instance(
+            code_sandbox_runtime=self.code_sandbox_runtime,
+            remote_path=self.cwd,
+        ) as code_interpreter:
             orig_chat = copy.deepcopy(chat)
             int_chat = copy.deepcopy(chat)
             last_user_message = chat[-1]
-            media_list = []
             for chat_i in int_chat:
                 if "media" in chat_i:
                     for media in chat_i["media"]:
                         media = cast(str, media)
-                        artifacts.artifacts[Path(media).name] = open(media, "rb").read()
-
-                        media_remote_path = (
-                            Path(artifacts.remote_save_path.parent) / Path(media).name
-                        )
-                        chat_i["content"] += f" Media name {media_remote_path}"  # type: ignore
-                        media_list.append(media_remote_path)
+                        artifacts[Path(media).name] = open(media, "rb").read()
 
             int_chat = cast(
                 List[Message],
@@ -452,15 +414,10 @@ class VisionAgent(Agent):
             iterations = 0
             last_response = None
 
-            # Save the current state of artifacts, will include any images the user
-            # passed in.
-            artifacts.save()
-
             # Upload artifacts to remote location and show where they are going
             # to be loaded to. The actual loading happens in BoilerplateCode as
             # part of the pre_code.
-            code_interpreter.upload_file(artifacts.local_save_path)
-            artifacts_loaded = artifacts.show(artifacts.remote_save_path.parent)
+            artifacts_loaded = artifacts.show()
             int_chat.append({"role": "observation", "content": artifacts_loaded})
             orig_chat.append({"role": "observation", "content": artifacts_loaded})
             self.streaming_message({"role": "observation", "content": artifacts_loaded})
@@ -487,10 +444,6 @@ class VisionAgent(Agent):
                 )
 
             while not finished and iterations < self.max_iterations:
-                # ensure we upload the artifacts before each turn, so any local
-                # modifications we made to it will be reflected in the remote
-                code_interpreter.upload_file(artifacts.local_save_path)
-
                 response = run_conversation(self.agent, int_chat)
                 code_action = use_extra_vision_agent_args(
                     response.get("execute_python", None),
@@ -558,14 +511,6 @@ class VisionAgent(Agent):
                         code_interpreter,
                     )
                     obs_chat_elt: Message = {"role": "observation", "content": obs}
-                    media_obs = check_and_load_image(code_action)
-                    if media_obs and result.success:
-                        # media paths will be under the local_save_path when we download
-                        # them after each turn
-                        obs_chat_elt["media"] = [
-                            artifacts.local_save_path.parent / media_ob
-                            for media_ob in media_obs
-                        ]
 
                     if self.verbosity >= 1:
                         _LOGGER.info(obs)
@@ -586,18 +531,10 @@ class VisionAgent(Agent):
                 iterations += 1
                 last_response = response
 
-                # after each turn, download the artifacts locally
-                code_interpreter.download_file(
-                    str(artifacts.remote_save_path.name),
-                    str(artifacts.local_save_path),
-                )
-                artifacts.load(
-                    artifacts.local_save_path, artifacts.local_save_path.parent
-                )
-
         return orig_chat, artifacts
 
     def streaming_message(self, message: Dict[str, Any]) -> None:
+        print(message)
         if self.callback_message:
             self.callback_message(message)
 
@@ -609,9 +546,9 @@ class OpenAIVisionAgent(VisionAgent):
     def __init__(
         self,
         agent: Optional[LMM] = None,
+        cwd: Optional[Union[Path, str]] = None,
         verbosity: int = 0,
         callback_message: Optional[Callable[[Dict[str, Any]], None]] = None,
-        code_interpreter: Optional[Union[str, CodeInterpreter]] = None,
     ) -> None:
         """Initialize the VisionAgent using OpenAI LMMs.
 
@@ -630,9 +567,9 @@ class OpenAIVisionAgent(VisionAgent):
         agent = OpenAILMM(temperature=0.0, json_mode=True) if agent is None else agent
         super().__init__(
             agent,
+            cwd,
             verbosity,
             callback_message,
-            code_interpreter,
         )
 
 
@@ -640,9 +577,9 @@ class AnthropicVisionAgent(VisionAgent):
     def __init__(
         self,
         agent: Optional[LMM] = None,
+        cwd: Optional[Union[Path, str]] = None,
         verbosity: int = 0,
         callback_message: Optional[Callable[[Dict[str, Any]], None]] = None,
-        code_interpreter: Optional[Union[str, CodeInterpreter]] = None,
     ) -> None:
         """Initialize the VisionAgent using Anthropic LMMs.
 
@@ -661,7 +598,7 @@ class AnthropicVisionAgent(VisionAgent):
         agent = AnthropicLMM(temperature=0.0) if agent is None else agent
         super().__init__(
             agent,
+            cwd,
             verbosity,
             callback_message,
-            code_interpreter,
         )

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -388,12 +388,6 @@ class VisionAgent(Agent):
             orig_chat = copy.deepcopy(chat)
             int_chat = copy.deepcopy(chat)
             last_user_message = chat[-1]
-            for chat_i in int_chat:
-                if "media" in chat_i:
-                    for media in chat_i["media"]:
-                        media = cast(str, media)
-                        artifacts[Path(media).name] = open(media, "rb").read()
-
             int_chat = cast(
                 List[Message],
                 [

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -38,7 +38,7 @@ class BoilerplateCode:
         "from vision_agent.tools.meta_tools import Artifacts, open_code_artifact, create_code_artifact, edit_code_artifact, get_tool_descriptions, generate_vision_code, edit_vision_code, view_media_artifact, object_detection_fine_tuning, use_object_detection_fine_tuning, list_artifacts",
         "artifacts = Artifacts('{cwd}')",
     ]
-    post_code = []
+    post_code: List[str] = []
 
     @staticmethod
     def add_boilerplate(code: str, **format: Any) -> str:

--- a/vision_agent/agent/vision_agent.py
+++ b/vision_agent/agent/vision_agent.py
@@ -437,7 +437,11 @@ class VisionAgent(Agent):
                 self.streaming_message(
                     {
                         "role": "observation",
-                        "content": user_obs,
+                        "content": (
+                            json.dumps(user_obs)
+                            if not isinstance(user_obs, str)
+                            else user_obs
+                        ),
                         "execution": user_result,
                         "finished": finished,
                     }
@@ -489,8 +493,10 @@ class VisionAgent(Agent):
                     self.streaming_message(
                         {
                             "role": "assistant",
-                            "content": new_format_to_old_format(
-                                add_step_descriptions(response)
+                            "content": json.dumps(
+                                new_format_to_old_format(
+                                    add_step_descriptions(response)
+                                )
                             ),
                             "finished": response.get("let_user_respond", False)
                             and code_action is None,
@@ -522,8 +528,10 @@ class VisionAgent(Agent):
                     self.streaming_message(
                         {
                             "role": "observation",
-                            "content": obs,
-                            "execution": result,
+                            "content": (
+                                json.dumps(obs) if not isinstance(obs, str) else obs
+                            ),
+                            "execution": result.to_json(),
                             "finished": finished,
                         }
                     )
@@ -534,7 +542,6 @@ class VisionAgent(Agent):
         return orig_chat, artifacts
 
     def streaming_message(self, message: Dict[str, Any]) -> None:
-        print(message)
         if self.callback_message:
             self.callback_message(message)
 

--- a/vision_agent/agent/vision_agent_coder.py
+++ b/vision_agent/agent/vision_agent_coder.py
@@ -561,12 +561,6 @@ class VisionAgentCoder(Agent):
             for chat_i in chat:
                 if "media" in chat_i:
                     for media in chat_i["media"]:
-                        media = (
-                            media
-                            if type(media) is str
-                            and media.startswith(("http", "https"))
-                            else code_interpreter.upload_file(cast(str, media))
-                        )
                         chat_i["content"] += f" Media name {media}"  # type: ignore
                         media_list.append(str(media))
 

--- a/vision_agent/agent/vision_agent_planner.py
+++ b/vision_agent/agent/vision_agent_planner.py
@@ -391,12 +391,6 @@ class VisionAgentPlanner(Agent):
             for chat_i in chat:
                 if "media" in chat_i:
                     for media in chat_i["media"]:
-                        media = (
-                            media
-                            if type(media) is str
-                            and media.startswith(("http", "https"))
-                            else code_interpreter.upload_file(cast(str, media))
-                        )
                         chat_i["content"] += f" Media name {media}"  # type: ignore
                         media_list.append(str(media))
 

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -73,95 +73,41 @@ class Artifacts:
     need to be in sync with the remote environment the VisionAgent is running in.
     """
 
-    def __init__(
-        self, remote_save_path: Union[str, Path], local_save_path: Union[str, Path]
-    ) -> None:
+    def __init__(self, cwd: Union[str, Path]) -> None:
         """Initializes the Artifacts object with it's remote and local save paths.
 
         Parameters:
-            remote_save_path (Union[str, Path]): The path to save the artifacts in the
-                remote environment. For example "/home/user/artifacts.pkl".
-            local_save_path (Union[str, Path]): The path to save the artifacts in the
-                local environment. For example "/Users/my_user/workspace/artifacts.pkl".
+            cwd (Union[str, Path]): The path to save all the chat related files. For example "/home/user/chat_abc/".
         """
-        self.remote_save_path = Path(remote_save_path)
-        self.local_save_path = Path(local_save_path)
-        self.artifacts: Dict[str, Any] = {}
+        self.cwd = Path(cwd)
 
-        self.code_sandbox_runtime = None
-
-    def load(
-        self,
-        artifacts_path: Union[str, Path],
-        load_to_dir: Optional[Union[str, Path]] = None,
-    ) -> None:
-        """Loads are artifacts into the load_to_dir directory. If load_to_dir is None,
-        it will load into remote_save_path directory. If an artifact value is None it
-        will skip loading it.
-
-        Parameters:
-            artifacts_path (Union[str, Path]): The file path to load the artifacts from.
-                If you are in the remote environment this would be remote_save_path, if
-                you are in the local environment this would be local_save_path.
-            load_to_dir (Optional[Union[str, Path]): The directory to load the artifacts
-                into. If None, it will load into remote_save_path directory.
-        """
-        with open(artifacts_path, "rb") as f:
-            self.artifacts = pkl.load(f)
-
-        load_to_dir = (
-            self.remote_save_path.parent if load_to_dir is None else Path(load_to_dir)
-        )
-
-        for k, v in self.artifacts.items():
-            if v is not None:
-                mode = "w" if isinstance(v, str) else "wb"
-                with open(load_to_dir / k, mode) as f:
-                    f.write(v)
-
-    def show(self, uploaded_file_dir: Optional[Union[str, Path]] = None) -> str:
-        """Prints out the artifacts and the directory they have been loaded to. If you
-        pass in upload_file_dir, it will show the artifacts have been loaded to the
-        upload_file_dir directory. If you don't pass in upload_file_dir, it will show
-        the artifacts have been loaded to the remote_save_path directory.
-
-        Parameters:
-            uploaded_file_dir (Optional[Union[str, Path]): The directory the artifacts
-                have been loaded to.
-        """
-        loaded_path = (
-            Path(uploaded_file_dir)
-            if uploaded_file_dir is not None
-            else self.remote_save_path.parent
-        )
+    def show(self) -> str:
+        """Prints out all the files in the curret working directory"""
         output_str = "[Artifacts loaded]\n"
-        for k in self.artifacts.keys():
-            output_str += (
-                f"Artifact name: {k}, loaded to path: {str(loaded_path / k)}\n"
-            )
+        for k in self:
+            output_str += f"Artifact name: {k}, loaded to path: {str(self.cwd / k)}\n"
         output_str += "[End of artifacts]\n"
         print(output_str)
         return output_str
 
-    def save(self, local_path: Optional[Union[str, Path]] = None) -> None:
-        """Saves the artifacts to the local_save_path directory. If local_path is None,
-        it will save to the local_save_path directory.
-        """
-        save_path = Path(local_path) if local_path is not None else self.local_save_path
-        with open(save_path, "wb") as f:
-            pkl.dump(self.artifacts, f)
-
     def __iter__(self) -> Any:
-        return iter(self.artifacts)
+        return iter(os.listdir(self.cwd))
 
     def __getitem__(self, name: str) -> Any:
-        return self.artifacts[name]
+        file_path = self.cwd / name
+        if file_path.exists():
+            with open(file_path, "r") as file:
+                return file.read()
+        else:
+            raise KeyError(f"File '{name}' not found in artifacts")
 
     def __setitem__(self, name: str, value: Any) -> None:
-        self.artifacts[name] = value
+        file_path = self.cwd / name
+        with open(file_path, "w") as file:
+            file.write(value)
 
     def __contains__(self, name: str) -> bool:
-        return name in self.artifacts
+        return name in os.listdir(self.cwd)
 
 
 def filter_file(file_name: Union[str, Path]) -> Tuple[bool, bool]:
@@ -173,27 +119,6 @@ def filter_file(file_name: Union[str, Path]) -> Tuple[bool, bool]:
         and file_name_p.suffix
         in [".png", ".jpeg", ".jpg", ".mp4", ".txt", ".json", ".csv"]
     ), file_name_p.suffix in [".png", ".jpeg", ".jpg", ".mp4"]
-
-
-def capture_files_into_artifacts(artifacts: Artifacts) -> None:
-    """This function is used to capture all files in the current directory into an
-    artifact object. This is useful if you want to capture all files in the current
-    directory and use them in a different environment where you don't have access to
-    the file system.
-
-    Parameters:
-        artifact (Artifacts): The artifact object to save the files to.
-    """
-    for file in Path(".").glob("**/*"):
-        usable_file, is_media = filter_file(file)
-        mode = "rb" if is_media else "r"
-        if usable_file:
-            file_name = file.name
-            if file_name.startswith(str(Path(artifacts.remote_save_path).parents)):
-                idx = len(Path(artifacts.remote_save_path).parents)
-                file_name = file_name[idx:]
-            with open(file, mode) as f:
-                artifacts[file_name] = f.read()
 
 
 # These tools are adapted from SWE-Agent https://github.com/princeton-nlp/SWE-agent

--- a/vision_agent/tools/meta_tools.py
+++ b/vision_agent/tools/meta_tools.py
@@ -1,7 +1,6 @@
 import difflib
 import json
 import os
-import pickle as pkl
 import re
 import subprocess
 import tempfile


### PR DESCRIPTION
Currently we implement the `Artifact` based on the pickle.
This requires to load / save the files.

This PR changes the `Artifact` to be folder-based.
There is no need to load / save any more.
All the files under the `cwd` (current working directory) will be treated as the files inside the Artifact.

Also we want to keep the `chat_with_artifacts` running in the same environment with the code_interpreter. So we don't have to maintain "local" and "remote".


---

Local test

Code:

```python
from vision_agent.agent import VisionAgent
from vision_agent.tools.meta_tools import Artifacts


artifacts = Artifacts("/Users/zhichao/Projects/vision-agent-chat/va-local-test")

agent = VisionAgent(verbosity=1)
resp, artifacts = agent.chat_with_artifacts(
    [
        {
            "role": "user",
            "content": "Can you write code to detect the car and visualize the detection?",
        }
    ],
    artifacts=artifacts,
    test_multi_plan=False,
)
resp.append({"role": "user", "content": "Can you describe the output image?"})
resp, artifacts = agent.chat_with_artifacts(resp, artifacts, test_multi_plan=False)
```

Result:
<img width="2560" alt="image" src="https://github.com/user-attachments/assets/ff9d661f-51e6-4661-ab73-be9a52274c5a">

<img width="2548" alt="image" src="https://github.com/user-attachments/assets/0d67b9b4-753d-43de-b98a-31ab115a691b">


---

Also tested the `view_media_artifact` action, the result looks good now.
<img width="1443" alt="image" src="https://github.com/user-attachments/assets/766b5691-da01-4709-8212-0b9390db2b1b">

