### PR TITLE
chore: add qwen2vl model for image and video into function tools

### DIFF
--- a/tests/integ/test_tools.py
+++ b/tests/integ/test_tools.py
@@ -34,6 +34,7 @@ from vision_agent.tools import (
     vit_image_classification,
     vit_nsfw_classification,
     qwen2_vl_images_vqa,
+    qwen2_vl_video_vqa,
     video_temporal_localization,
 )
 
@@ -376,6 +377,17 @@ def test_qwen2_vl_images_vqa():
         images=[img],
     )
     assert len(result) > 0
+
+
+def test_qwen2_vl_video_vqa():
+    frames = [
+        np.array(Image.fromarray(ski.data.cat()).convert("RGB")) for _ in range(10)
+    ]
+    result = qwen2_vl_video_vqa(
+        prompt="What animal is in this video?",
+        frames=frames,
+    )
+    assert "cat" in result.strip()
 
 
 def test_ixc25_video_vqa():

--- a/vision_agent/tools/__init__.py
+++ b/vision_agent/tools/__init__.py
@@ -66,6 +66,7 @@ from .tools import (
     vit_image_classification,
     vit_nsfw_classification,
     qwen2_vl_images_vqa,
+    qwen2_vl_video_vqa,
     video_temporal_localization,
 )
 

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -930,6 +930,37 @@ def ixc25_video_vqa(prompt: str, frames: List[np.ndarray]) -> str:
     return cast(str, data["answer"])
 
 
+def qwen2_vl_video_vqa(prompt: str, frames: List[np.ndarray]) -> str:
+    """'qwen2_vl_video_vqa' is a tool that can answer any questions about arbitrary videos
+    including regular videos or videos of documents or presentations. It returns text
+    as an answer to the question.
+
+    Parameters:
+        prompt (str): The question about the video
+        frames (List[np.ndarray]): The reference frames used for the question
+
+    Returns:
+        str: A string which is the answer to the given prompt.
+
+    Example
+    -------
+        >>> qwen2_vl_video_vqa('Which football player made the goal?', frames)
+        'Lionel Messi'
+    """
+
+    buffer_bytes = frames_to_bytes(frames)
+    files = [("video", buffer_bytes)]
+    payload = {
+        "prompt": prompt,
+        "model": "qwen2vl",
+        "function_name": "qwen2_vl_video_vqa",
+    }
+    data: Dict[str, Any] = send_inference_request(
+        payload, "image-to-text", files=files, v2=True
+    )
+    return cast(str, data)
+
+
 def gpt4o_image_vqa(prompt: str, image: np.ndarray) -> str:
     """'gpt4o_image_vqa' is a tool that can answer any questions about arbitrary images
     including regular images or images of documents or presentations. It returns text
@@ -2238,13 +2269,13 @@ FUNCTION_TOOLS = [
     florence2_sam2_image,
     florence2_sam2_video_tracking,
     florence2_phrase_grounding,
-    ixc25_image_vqa,
-    ixc25_video_vqa,
     detr_segmentation,
     depth_anything_v2,
     generate_pose_image,
     closest_mask_distance,
     closest_box_distance,
+    qwen2_vl_images_vqa,
+    qwen2_vl_video_vqa,
 ]
 
 UTIL_TOOLS = [


### PR DESCRIPTION
Description
---
* Create the `qwen2_vl_video_vqa` tool for video analysis
* Add test for `qwen2_vl_video_vqa`
* Add the `qwen2_vl_images_vqa` and `qwen2_vl_video_vqa`
* Remove the `ixc25_image_vqa` and `ixc25_video_vqa` from the function tools list

Tests
---
![Screenshot 2024-10-29 at 5 57 54 PM](https://github.com/user-attachments/assets/ee9672e2-6c70-41c4-ae7c-f8027ca07f5b)
