### PR TITLE
feat: support loading base64 encoded image or video

### DIFF
--- a/tests/unit/tools/test_tools.py
+++ b/tests/unit/tools/test_tools.py
@@ -1,10 +1,51 @@
+import base64
 import os
 import tempfile
 from pathlib import Path
 
+import cv2
 import numpy as np
 
-from vision_agent.tools.tools import overlay_bounding_boxes, save_image, save_video
+from vision_agent.tools.tools import (
+    load_image,
+    overlay_bounding_boxes,
+    save_image,
+    save_video,
+)
+
+
+def test_load_image_from_file_path(tmp_path: Path):
+    image_array = np.random.randint(0, 256, (480, 640, 3), dtype=np.uint8)
+    image_path = tmp_path / "test.jpg"
+    cv2.imwrite(image_path, image_array)
+
+    image = load_image(str(image_path))
+    assert isinstance(image, np.ndarray)
+    assert image.shape == (480, 640, 3)
+
+
+def test_load_image_from_url():
+    image_url = "https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg"
+    image = load_image(image_url)
+    assert isinstance(image, np.ndarray)
+    assert image.shape == (300, 300, 3)
+
+
+def test_load_image_from_base64():
+    image_array = np.random.randint(0, 256, (480, 640, 3), dtype=np.uint8)
+    img_bytes = cv2.imencode(".jpg", image_array)[1].tobytes()
+    image_base64 = base64.b64encode(img_bytes).decode("utf-8")
+    image_base64 = f"data:image/jpeg;base64,{image_base64}"
+    image = load_image(image_base64)
+    assert isinstance(image, np.ndarray)
+    assert image.shape == (480, 640, 3)
+
+
+def test_load_image_from_numpy_array():
+    image_array = np.random.randint(0, 256, (480, 640, 3), dtype=np.uint8)
+    image = load_image(image_array)
+    assert isinstance(image, np.ndarray)
+    assert np.array_equal(image, image_array)
 
 
 def test_saves_frames_without_output_path():

--- a/tests/unit/tools/test_video.py
+++ b/tests/unit/tools/test_video.py
@@ -1,3 +1,4 @@
+import base64
 import tempfile
 from typing import Optional
 
@@ -5,6 +6,17 @@ import cv2
 import numpy as np
 
 from vision_agent.utils.video import extract_frames_from_video
+
+
+def test_extract_frames_from_base64_video():
+    video_path = _create_video(duration=2)
+    with open(video_path, "rb") as f:
+        video_bytes = f.read()
+    video_base64 = (
+        f"data:video/mp4;base64,{base64.b64encode(video_bytes).decode('utf-8')}"
+    )
+    res = extract_frames_from_video(video_base64, fps=24)
+    assert len(res) == 48
 
 
 def test_extract_frames_from_video():

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -1942,7 +1942,7 @@ def save_json(data: Any, file_path: str) -> None:
         json.dump(data, f, cls=NumpyEncoder)
 
 
-def load_image(image: str | np.ndarray) -> np.ndarray:
+def load_image(image: Union[str, np.ndarray]) -> np.ndarray:
     """'load_image' is a utility function that loads an image from the given file path string or an URL.
 
     Parameters:


### PR DESCRIPTION
**Context**
It's convenient for a web endpoint to send base64 encoded image or video.

Thus, update the `load_image` and `extract_frames_from_video` tool to support it.