### PR TITLE
Better handle two edge cases in tools

### DIFF
--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -1871,6 +1871,9 @@ def extract_frames_and_timestamps(
         >>> extract_frames("path/to/video.mp4")
         [{"frame": np.ndarray, "timestamp": 0.0}, ...]
     """
+    if isinstance(fps, str):
+        # fps could be a string when it's passed in from a web endpoint deployment
+        fps = float(fps)
 
     def reformat(
         frames_and_timestamps: List[Tuple[np.ndarray, float]],
@@ -1934,6 +1937,7 @@ def save_json(data: Any, file_path: str) -> None:
                 return bool(obj)
             return json.JSONEncoder.default(self, obj)
 
+    Path(file_path).parent.mkdir(parents=True, exist_ok=True)
     with open(file_path, "w") as f:
         json.dump(data, f, cls=NumpyEncoder)
 
@@ -1976,6 +1980,7 @@ def save_image(image: np.ndarray, file_path: str) -> None:
     -------
         >>> save_image(image)
     """
+    Path(file_path).parent.mkdir(parents=True, exist_ok=True)
     from IPython.display import display
 
     if not isinstance(image, np.ndarray) or (
@@ -2006,6 +2011,9 @@ def save_video(
         >>> save_video(frames)
         "/tmp/tmpvideo123.mp4"
     """
+    if isinstance(fps, str):
+        # fps could be a string when it's passed in from a web endpoint deployment
+        fps = float(fps)
     if fps <= 0:
         raise ValueError(f"fps must be greater than 0 got {fps}")
 
@@ -2022,6 +2030,8 @@ def save_video(
         output_video_path = tempfile.NamedTemporaryFile(
             delete=False, suffix=".mp4"
         ).name
+    else:
+        Path(output_video_path).parent.mkdir(parents=True, exist_ok=True)
 
     output_video_path = video_writer(frames, fps, output_video_path)
     _save_video_to_result(output_video_path)

--- a/vision_agent/utils/video.py
+++ b/vision_agent/utils/video.py
@@ -58,6 +58,9 @@ def video_writer(
     fps: float = _DEFAULT_INPUT_FPS,
     filename: Optional[str] = None,
 ) -> str:
+    if isinstance(fps, str):
+        # fps could be a string when it's passed in from a web endpoint deployment
+        fps = float(fps)
     if filename is None:
         filename = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4").name
     container = av.open(filename, mode="w")
@@ -92,6 +95,9 @@ def frames_to_bytes(
         fps: the frames per second of the video
         file_ext: the file extension of the video file
     """
+    if isinstance(fps, str):
+        # fps could be a string when it's passed in from a web endpoint deployment
+        fps = float(fps)
     with tempfile.NamedTemporaryFile(delete=True, suffix=file_ext) as temp_file:
         video_writer(frames, fps, temp_file.name)
 
@@ -120,6 +126,9 @@ def extract_frames_from_video(
             from the start of the video. E.g. 12.125 means 12.125 seconds from the start of
             the video. The frames are sorted by the timestamp in ascending order.
     """
+    if isinstance(fps, str):
+        # fps could be a string when it's passed in from a web endpoint deployment
+        fps = float(fps)
 
     cap = cv2.VideoCapture(video_uri)
     orig_fps = cap.get(cv2.CAP_PROP_FPS)


### PR DESCRIPTION
Better handle two edge cases in tools:
1. `fps` could be a str when it's passed in from a web deployment. So convert fps to float when it's a str.
2. Create the parent folder if it doesn't exist when saving file/image/video on disk.