### PR TITLE
fix: owl_v2_video tool response format

### DIFF
--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -410,7 +410,7 @@ def owl_v2_video(
     _display_tool_trace(
         owl_v2_video.__name__,
         payload,
-        detections[0],
+        detections,
         files,
     )
     return bboxes_formatted


### PR DESCRIPTION
### Issue
The response from owl_v2_video is the same as owl_v2_image (array of od annotations), but the expected response should be frames (array of array of od annotations).

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/61c4d9e2-57cc-4603-bfd3-41590dbb942a" />

### Test

<img width="1234" alt="image" src="https://github.com/user-attachments/assets/0dd43c1d-d976-4b9e-b32f-be913bc1f934" />
