### PR TITLE
only report tool traces in code generation time

### DIFF
--- a/vision_agent/tools/tool_utils.py
+++ b/vision_agent/tools/tool_utils.py
@@ -13,6 +13,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from vision_agent.tools.tools_types import BoundingBoxes
+from vision_agent.utils import should_report_tool_traces
 from vision_agent.utils.exceptions import RemoteToolCallFailed
 from vision_agent.utils.execute import Error, MimeType
 from vision_agent.utils.image_utils import normalize_bbox
@@ -251,7 +252,7 @@ def _call_post(
         tool_call_trace.response = result
         return result
     finally:
-        if tool_call_trace is not None:
+        if tool_call_trace is not None and should_report_tool_traces():
             trace = tool_call_trace.model_dump()
             display({MimeType.APPLICATION_JSON: trace}, raw=True)
 

--- a/vision_agent/tools/tool_utils.py
+++ b/vision_agent/tools/tool_utils.py
@@ -13,7 +13,6 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from vision_agent.tools.tools_types import BoundingBoxes
-from vision_agent.utils import should_report_tool_traces
 from vision_agent.utils.exceptions import RemoteToolCallFailed
 from vision_agent.utils.execute import Error, MimeType
 from vision_agent.utils.image_utils import normalize_bbox
@@ -24,6 +23,10 @@ _LND_API_KEY = os.environ.get("LANDINGAI_API_KEY", LandingaiAPIKey().api_key)
 _LND_BASE_URL = os.environ.get("LANDINGAI_URL", "https://api.landing.ai")
 _LND_API_URL = f"{_LND_BASE_URL}/v1/agent/model"
 _LND_API_URL_v2 = f"{_LND_BASE_URL}/v1/tools"
+
+
+def should_report_tool_traces() -> bool:
+    return bool(os.environ.get("REPORT_TOOL_TRACES", False))
 
 
 class ToolCallTrace(BaseModel):

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -32,10 +32,10 @@ from vision_agent.tools.tool_utils import (
     nms,
     send_inference_request,
     send_task_inference_request,
+    should_report_tool_traces,
     single_nms,
 )
 from vision_agent.tools.tools_types import JobStatus
-from vision_agent.utils import should_report_tool_traces
 from vision_agent.utils.exceptions import FineTuneModelIsNotReady
 from vision_agent.utils.execute import FileSerializer, MimeType
 from vision_agent.utils.image_utils import (

--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -35,6 +35,7 @@ from vision_agent.tools.tool_utils import (
     single_nms,
 )
 from vision_agent.tools.tools_types import JobStatus
+from vision_agent.utils import should_report_tool_traces
 from vision_agent.utils.exceptions import FineTuneModelIsNotReady
 from vision_agent.utils.execute import FileSerializer, MimeType
 from vision_agent.utils.image_utils import (
@@ -94,6 +95,9 @@ def _display_tool_trace(
     # such as video bytes, which can be slow. Since this is calculated inside the
     # function we can't capture it with a decarator without adding it as a return value
     # which would change the function signature and affect the agent.
+    if not should_report_tool_traces():
+        return
+
     files_in_b64: List[Tuple[str, str]]
     if isinstance(files, str):
         files_in_b64 = [("images", files)]
@@ -264,7 +268,7 @@ def od_sam2_video_tracking(
     image_size = frames[0].shape[:2]
 
     def _transform_detections(
-        input_list: List[Optional[List[Dict[str, Any]]]]
+        input_list: List[Optional[List[Dict[str, Any]]]],
     ) -> List[Optional[Dict[str, Any]]]:
         output_list: List[Optional[Dict[str, Any]]] = []
 
@@ -2243,15 +2247,17 @@ def save_image(image: np.ndarray, file_path: str) -> None:
         >>> save_image(image)
     """
     Path(file_path).parent.mkdir(parents=True, exist_ok=True)
-    from IPython.display import display
-
     if not isinstance(image, np.ndarray) or (
         image.shape[0] == 0 and image.shape[1] == 0
     ):
         raise ValueError("The image is not a valid NumPy array with shape (H, W, C)")
 
     pil_image = Image.fromarray(image.astype(np.uint8)).convert("RGB")
-    display(pil_image)
+    if should_report_tool_traces():
+        from IPython.display import display
+
+        display(pil_image)
+
     pil_image.save(file_path)
 
 
@@ -2302,6 +2308,9 @@ def save_video(
 
 def _save_video_to_result(video_uri: str) -> None:
     """Saves a video into the result of the code execution (as an intermediate output)."""
+    if not should_report_tool_traces():
+        return
+
     from IPython.display import display
 
     serializer = FileSerializer(video_uri)

--- a/vision_agent/utils/__init__.py
+++ b/vision_agent/utils/__init__.py
@@ -1,3 +1,4 @@
+import os
 from .execute import (
     CodeInterpreter,
     CodeInterpreterFactory,
@@ -7,3 +8,7 @@ from .execute import (
     Result,
 )
 from .sim import AzureSim, OllamaSim, Sim, load_sim, merge_sim
+
+
+def should_report_tool_traces() -> bool:
+    return os.environ.get("REPORT_TOOL_TRACES", False)

--- a/vision_agent/utils/__init__.py
+++ b/vision_agent/utils/__init__.py
@@ -11,4 +11,4 @@ from .sim import AzureSim, OllamaSim, Sim, load_sim, merge_sim
 
 
 def should_report_tool_traces() -> bool:
-    return os.environ.get("REPORT_TOOL_TRACES", False)
+    return bool(os.environ.get("REPORT_TOOL_TRACES", False))

--- a/vision_agent/utils/__init__.py
+++ b/vision_agent/utils/__init__.py
@@ -1,4 +1,3 @@
-import os
 from .execute import (
     CodeInterpreter,
     CodeInterpreterFactory,
@@ -8,7 +7,3 @@ from .execute import (
     Result,
 )
 from .sim import AzureSim, OllamaSim, Sim, load_sim, merge_sim
-
-
-def should_report_tool_traces() -> bool:
-    return bool(os.environ.get("REPORT_TOOL_TRACES", False))


### PR DESCRIPTION
## Motivation
The `ipython.display.display` function is used to save data so it can be reported to our frontend web app.

As a side effect:
1.  The display function brings in non-trivial latency overhead when processing video files because it serializes video frames and prints them to stdout.
2. It floods the log making debugging harder.

`display()` is only useful in code generation time and when the frontend app is up. It's not used when users run the generated code offline.

## Changes
Introduce a new env var `REPORT_TOOL_TRACES`, and VA only report traces when the env var is present.
