### PR TITLE
Fix windows permission issue

### DIFF
--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -2804,7 +2804,7 @@ def save_video(
     else:
         Path(output_video_path).parent.mkdir(parents=True, exist_ok=True)
 
-    output_video_path = video_writer(frames, fps, output_video_path)
+    output_video_path = video_writer(frames, fps, filename=output_video_path)
     _save_video_to_result(output_video_path)
     return output_video_path
 

--- a/vision_agent/utils/video.py
+++ b/vision_agent/utils/video.py
@@ -2,6 +2,7 @@ import logging
 import os
 import tempfile
 from functools import lru_cache
+from pathlib import Path
 from typing import List, Optional, Tuple
 
 import av  # type: ignore
@@ -25,8 +26,8 @@ def _resize_frame(frame: np.ndarray) -> np.ndarray:
 def video_writer(
     frames: List[np.ndarray],
     fps: float = _DEFAULT_INPUT_FPS,
-    file_ext: str = ".mp4",
     filename: Optional[str] = None,
+    file_ext: str = ".mp4",
 ) -> str:
     if isinstance(fps, str):
         # fps could be a string when it's passed in from a web endpoint deployment

--- a/vision_agent/utils/video.py
+++ b/vision_agent/utils/video.py
@@ -2,7 +2,6 @@ import logging
 import os
 import tempfile
 from functools import lru_cache
-from pathlib import Path
 from typing import List, Optional, Tuple
 
 import av  # type: ignore


### PR DESCRIPTION
Fixes a permission issue on Windows in `frames_to_bytes`, it's caused when calling `with tempfile.NamedTemporaryFile(delete=True, ...)`, delete must be set to false, and then the file later deleted manually.

More info on this from the python docs https://docs.python.org/3/library/tempfile.html


Opening the temporary file again by its name while it is still open works as follows:

- On POSIX the file can always be opened again.
- On Windows, make sure that at least one of the following conditions are fulfilled:
    - delete is false
    - additional open shares delete access (e.g. by calling [os.open()](https://docs.python.org/3/library/os.html#os.open) with the flag O_TEMPORARY)
    - delete is true but delete_on_close is false. Note, that in this case the additional opens that do not share delete access (e.g. created via builtin [open()](https://docs.python.org/3/library/functions.html#open)) must be closed before exiting the context manager, else the [os.unlink()](https://docs.python.org/3/library/os.html#os.unlink) call on context manager exit will fail with a [PermissionError](https://docs.python.org/3/library/exceptions.html#PermissionError).
