### PR TITLE
Fix Crash Cases

### DIFF
--- a/vision_agent/agent/vision_agent_coder_v2.py
+++ b/vision_agent/agent/vision_agent_coder_v2.py
@@ -13,6 +13,7 @@ from vision_agent.lmm import LMM
 from vision_agent.models import (
     AgentMessage,
     CodeContext,
+    ErrorContext,
     InteractionContext,
     Message,
     PlanContext,
@@ -372,7 +373,7 @@ class VisionAgentCoderV2(AgentCoder):
         chat: List[AgentMessage],
         max_steps: Optional[int] = None,
         code_interpreter: Optional[CodeInterpreter] = None,
-    ) -> Union[CodeContext, InteractionContext]:
+    ) -> Union[CodeContext, InteractionContext, ErrorContext]:
         """Generate vision code from a conversation.
 
         Parameters:
@@ -403,6 +404,8 @@ class VisionAgentCoderV2(AgentCoder):
             )
             # the planner needs an interaction, so return before generating code
             if isinstance(plan_context, InteractionContext):
+                return plan_context
+            elif isinstance(plan_context, ErrorContext):
                 return plan_context
 
             code_context = self.generate_code_from_plan(

--- a/vision_agent/agent/vision_agent_prompts_v2.py
+++ b/vision_agent/agent/vision_agent_prompts_v2.py
@@ -16,16 +16,28 @@ AGENT: <response>Yes, I can help you with that. I will write the code to detect 
 OBSERVATION:
 <final_code>
 from vision_agent.tools import load_image, owl_v2_image
-def detect_dogs(image_path: str):
+def detect_dogs(image_path: str) -> int:
     image = load_image(image_path)
     dogs = owl_v2_image(image)
-    return dogs
+    return len(dogs)
 </final_code>
 <final_test>
 def test_detect_dogs():
     dogs = detect_dogs("images/dogs.jpg")
-    assert len(dogs) > 0
+    assert isinstance(dogs, int)
+    print(f"Number of dogs detected: {dogs}")
+    return dogs
 </final_test>
+
+OBSERVATION: ----- stdout -----
+Number of dogs detected: 8
+
+----- stderr -----
+
+----- Intermediate output-----
+None
+----- Final output -----
+8
 
 AGENT: <response>Here is the code to detect dogs in the image.</response>
 --- END EXAMPLE1 ---

--- a/vision_agent/agent/vision_agent_prompts_v2.py
+++ b/vision_agent/agent/vision_agent_prompts_v2.py
@@ -25,7 +25,7 @@ def detect_dogs(image_path: str) -> int:
 def test_detect_dogs():
     dogs = detect_dogs("images/dogs.jpg")
     assert isinstance(dogs, int)
-    print(f"Number of dogs detected: {dogs}")
+    print(f"Number of dogs detected: {{dogs}}")
     return dogs
 </final_test>
 

--- a/vision_agent/agent/vision_agent_v2.py
+++ b/vision_agent/agent/vision_agent_v2.py
@@ -28,7 +28,9 @@ CONFIG = Config()
 
 
 def extract_conversation(
-    chat: List[AgentMessage], include_conv: bool = False
+    chat: List[AgentMessage],
+    include_conv: bool = False,
+    include_errors: bool = False,
 ) -> Tuple[List[AgentMessage], Optional[str]]:
     chat = copy.deepcopy(chat)
 
@@ -38,22 +40,24 @@ def extract_conversation(
         return chat, None
 
     extracted_chat = []
-    for i, chat_i in enumerate(chat):
+    for chat_i in chat:
         if chat_i.role == "user":
             extracted_chat.append(chat_i)
         elif chat_i.role == "coder":
             if "<final_code>" in chat_i.content:
                 extracted_chat.append(chat_i)
-                # keep corresponding observation from final code execution
-                if i + 1 < len(chat) and chat[i + 1].role == "observation":
-                    extracted_chat.append(chat[i + 1])
+        elif chat_i.role == "final_observation":
+            extracted_chat.append(chat_i)
         elif include_conv and chat_i.role == "conversation":
             extracted_chat.append(chat_i)
+        elif include_errors and chat_i.role == "error_observation":
+            extracted_chat.append(chat_i)
 
-    # only keep the last <final_code>, <final_test> and their corresponding observation
+    # only keep the last <final_code>, <final_test>
     final_code = None
     extracted_chat_strip_code: List[AgentMessage] = []
-    for i, chat_i in reversed(list(enumerate(extracted_chat))):
+    for chat_i in reversed((extracted_chat)):
+        # don't check role here because user could send updated <final_code>
         if "<final_code>" in chat_i.content and final_code is None:
             extracted_chat_strip_code = [chat_i] + extracted_chat_strip_code
             final_code = extract_tag(chat_i.content, "final_code")
@@ -70,7 +74,12 @@ def extract_conversation(
 
 
 def run_conversation(agent: LMM, chat: List[AgentMessage]) -> str:
-    extracted_chat, _ = extract_conversation(chat, include_conv=True)
+    # Include conversation and error messages. The error messages can come from one of
+    # the agents refusing to write a correctly formatted message, want to inform the
+    # conversation agent of this.
+    extracted_chat, _ = extract_conversation(
+        chat, include_conv=True, include_errors=True
+    )
 
     conv = format_conversation(extracted_chat)
     prompt = CONVERSATION.format(
@@ -105,7 +114,9 @@ def maybe_run_action(
         if isinstance(context, CodeContext):
             return [
                 AgentMessage(role="coder", content=format_code_context(context)),
-                AgentMessage(role="observation", content=context.test_result.text()),
+                AgentMessage(
+                    role="final_observation", content=context.test_result.text()
+                ),
             ]
         elif isinstance(context, InteractionContext):
             return [
@@ -116,7 +127,7 @@ def maybe_run_action(
             ]
         elif isinstance(context, ErrorContext):
             return [
-                AgentMessage(role="observation", content=context.error),
+                AgentMessage(role="error_observation", content=context.error),
             ]
     elif action == "edit_code":
         # We don't want to pass code in plan_context.code so the coder will generate
@@ -137,7 +148,7 @@ def maybe_run_action(
         )
         return [
             AgentMessage(role="coder", content=format_code_context(context)),
-            AgentMessage(role="observation", content=context.test_result.text()),
+            AgentMessage(role="final_observation", content=context.test_result.text()),
         ]
     elif action == "view_image":
         pass

--- a/vision_agent/models/__init__.py
+++ b/vision_agent/models/__init__.py
@@ -1,4 +1,10 @@
-from .agent_types import AgentMessage, CodeContext, InteractionContext, PlanContext
+from .agent_types import (
+    AgentMessage,
+    CodeContext,
+    ErrorContext,
+    InteractionContext,
+    PlanContext,
+)
 from .lmm_types import Message, TextOrImage
 from .tools_types import (
     BboxInput,

--- a/vision_agent/models/agent_types.py
+++ b/vision_agent/models/agent_types.py
@@ -75,3 +75,12 @@ class InteractionContext(BaseModel):
     """
 
     chat: List[AgentMessage]
+
+
+class ErrorContext(BaseModel):
+    """ErrorContext is a data model that represents an error message.
+
+    error: The error message.
+    """
+
+    error: str

--- a/vision_agent/models/agent_types.py
+++ b/vision_agent/models/agent_types.py
@@ -29,11 +29,15 @@ class AgentMessage(BaseModel):
         Literal["user"],
         Literal["assistant"],  # planner, coder and conversation are of type assistant
         Literal["observation"],
+        Literal["final_observation"],  # the observation from the final code output
+        Literal["error_observation"],  # the observation from the error message
         Literal["interaction"],
         Literal["interaction_response"],
         Literal["conversation"],
         Literal["planner"],
-        Literal["planner_update"],
+        Literal[
+            "planner_update"
+        ],  # an intermediate update from the planner to show partial information
         Literal["coder"],
     ]
     content: str
@@ -78,7 +82,9 @@ class InteractionContext(BaseModel):
 
 
 class ErrorContext(BaseModel):
-    """ErrorContext is a data model that represents an error message.
+    """ErrorContext is a data model that represents an error message. These errors can
+    happen in the planning phase when a model does not output correctly formatted
+    messages (often because it considers some response to be a safety issue).
 
     error: The error message.
     """

--- a/vision_agent/utils/agent.py
+++ b/vision_agent/utils/agent.py
@@ -159,8 +159,13 @@ def format_conversation(chat: List[AgentMessage]) -> str:
     chat = copy.deepcopy(chat)
     prompt = ""
     for chat_i in chat:
-        if chat_i.role == "user" or chat_i.role == "coder":
-            if "<final_code>" in chat_i.content:
+        if (
+            chat_i.role == "user"
+            or chat_i.role == "coder"
+            or chat_i.role == "observation"
+        ):
+            # we want to print the final code and it's corresponding observation
+            if "<final_code>" in chat_i.content or chat_i.role == "observation":
                 prompt += f"OBSERVATION: {chat_i.content}\n\n"
             elif chat_i.role == "user":
                 prompt += f"USER: {chat_i.content}\n\n"

--- a/vision_agent/utils/agent.py
+++ b/vision_agent/utils/agent.py
@@ -162,13 +162,16 @@ def format_conversation(chat: List[AgentMessage]) -> str:
         if (
             chat_i.role == "user"
             or chat_i.role == "coder"
-            or chat_i.role == "observation"
+            or chat_i.role == "final_observation"
+            or chat_i.role == "error_observation"
         ):
-            # we want to print the final code and it's corresponding observation
-            if "<final_code>" in chat_i.content or chat_i.role == "observation":
-                prompt += f"OBSERVATION: {chat_i.content}\n\n"
-            elif chat_i.role == "user":
+            # we want to print user messages, final code, final code observations or errors
+            if chat_i.role == "user":
                 prompt += f"USER: {chat_i.content}\n\n"
+            elif "<cinal_code>" in chat_i.content:
+                prompt += f"OBSERVATION: {chat_i.content}\n\n"
+            else:
+                prompt += f"OBERSVATION: {chat_i.content}\n\n"
         elif chat_i.role == "conversation":
             prompt += f"AGENT: {chat_i.content}\n\n"
     return prompt


### PR DESCRIPTION
This fixes several side case that cause the agent to crash or exhibit weird behavior:
- Sometimes the plan finalizer will refuse to format in JSON due to a safety concern, this causes the agent to crash. I now catch the error and propagate it back up to the conversation agent
- Previously error messages from the coder agent were not getting propagated back to the conversation agent, the conversation agent can now see these outupts.