### PR TITLE
Fix docs github action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,4 +45,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - run: mkdir -p docs-build
       - run: poetry run mkdocs build -f mkdocs.yml -d docs-build/
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: docs-build/
 


### PR DESCRIPTION
The version for `actions/upload-pages-artifacts` and `actions/deploy-pages` are out of date/deprecated. This updates the version https://github.com/actions/upload-pages-artifact