### PR TITLE
fixed wrong task_name in send_task_inference_request inside _agentic_object_detection

### DIFF
--- a/vision_agent/tools/tools.py
+++ b/vision_agent/tools/tools.py
@@ -1451,7 +1451,7 @@ def _agentic_object_detection(
 
     detections = send_task_inference_request(
         payload,
-        "text-to-object-detection",
+        "agentic-object-detection",
         files=files,
         metadata=metadata,
     )


### PR DESCRIPTION
I was working with Vision Agent and encountered that even when the `agentic_object_detection `is called the results were produced by the text-to-object detection API. 
For `_agentic_object_detection` the final URL call should be to `"https://api.landing.ai/v1/tools/agentic-object-detection"` 

As per the this page:
https://va.landing.ai/demo/agentic-od

`import requests
url = "https://api.landing.ai/v1/tools/agentic-object-detection"
files = {
  "image": open("{{path_to_image}}", "rb")
}
data = {
  "prompts": "{{prompt}}",
  "model": "agentic"
}
headers = {
  "Authorization": "Basic {{your_api_key}}"
}
response = requests.post(url, files=files, data=data, headers=headers)
print(response.json())`