### PR TITLE
feat: add X-Source to inference request header

### DIFF
--- a/vision_agent/sim/sim.py
+++ b/vision_agent/sim/sim.py
@@ -60,7 +60,7 @@ def stella_embeddings(prompts: List[str]) -> List[np.ndarray]:
     vision_agent_api_key = get_vision_agent_api_key()
     headers = {
         "Authorization": f"Basic {vision_agent_api_key}",
-        "X-Source": "vision-agent",
+        "X-Source": "vision_agent",
     }
     session = _create_requests_session(
         url=url,

--- a/vision_agent/sim/sim.py
+++ b/vision_agent/sim/sim.py
@@ -58,7 +58,10 @@ def stella_embeddings(prompts: List[str]) -> List[np.ndarray]:
     }
     url = f"{_LND_API_URL_v2}/embeddings"
     vision_agent_api_key = get_vision_agent_api_key()
-    headers = {"Authorization": f"Basic {vision_agent_api_key}"}
+    headers = {
+        "Authorization": f"Basic {vision_agent_api_key}",
+        "X-Source": "vision-agent",
+    }
     session = _create_requests_session(
         url=url,
         num_retry=3,

--- a/vision_agent/utils/tools.py
+++ b/vision_agent/utils/tools.py
@@ -58,7 +58,7 @@ def send_inference_request(
     vision_agent_api_key = get_vision_agent_api_key()
     headers = {
         "Authorization": f"Basic {vision_agent_api_key}",
-        "X-Source": "vision-agent",
+        "X-Source": "vision_agent",
     }
     if "TOOL_ENDPOINT_AUTH" in os.environ:
         headers["Authorization"] = os.environ["TOOL_ENDPOINT_AUTH"]
@@ -95,7 +95,7 @@ def send_task_inference_request(
     vision_agent_api_key = get_vision_agent_api_key()
     headers = {
         "Authorization": f"Basic {vision_agent_api_key}",
-        "X-Source": "vision-agent",
+        "X-Source": "vision_agent",
     }
     session = _create_requests_session(
         url=url,

--- a/vision_agent/utils/tools.py
+++ b/vision_agent/utils/tools.py
@@ -56,7 +56,10 @@ def send_inference_request(
         url = os.environ["TOOL_ENDPOINT_URL"]
 
     vision_agent_api_key = get_vision_agent_api_key()
-    headers = {"Authorization": f"Basic {vision_agent_api_key}"}
+    headers = {
+        "Authorization": f"Basic {vision_agent_api_key}",
+        "X-Source": "vision-agent",
+    }
     if "TOOL_ENDPOINT_AUTH" in os.environ:
         headers["Authorization"] = os.environ["TOOL_ENDPOINT_AUTH"]
         headers.pop("apikey")
@@ -90,7 +93,10 @@ def send_task_inference_request(
 ) -> Any:
     url = f"{_LND_API_URL_v2}/{task_name}"
     vision_agent_api_key = get_vision_agent_api_key()
-    headers = {"Authorization": f"Basic {vision_agent_api_key}"}
+    headers = {
+        "Authorization": f"Basic {vision_agent_api_key}",
+        "X-Source": "vision-agent",
+    }
     session = _create_requests_session(
         url=url,
         num_retry=3,


### PR DESCRIPTION
Tested locally and see MI has send inference history with vision_agent source
<img width="1344" alt="image" src="https://github.com/user-attachments/assets/d8184e64-dc1b-4caa-b0cd-8168b7d28c65" />
